### PR TITLE
Create a go binary that leverages Chef Server API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ results/
 # mac
 .DS_Store
 
+# all arch binaries
+bin/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# vim
+*.swp
+*.swo
+
+# Habitat
+results/
+
+# mac
+.DS_Store
+

--- a/.studiorc
+++ b/.studiorc
@@ -5,3 +5,10 @@
 hab pkg install chef/studio-common >/dev/null
 source "$(hab pkg path chef/studio-common)/bin/studio-common"
 
+function build_cross_platform() {
+  install_if_missing core/go go
+  install_if_missing core/gox gox
+  gox -output="bin/{{.Dir}}_{{.OS}}_{{.Arch}}" \
+      -os="darwin linux windows" \
+      -arch="amd64 386"
+}

--- a/.studiorc
+++ b/.studiorc
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# This is the place you can extend the funcitonality of the studio
+
+hab pkg install chef/studio-common >/dev/null
+source "$(hab pkg path chef/studio-common)/bin/studio-common"
+

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/chef/chef-analyze
+
+go 1.12
+
+require github.com/go-chef/chef v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/ctdk/goiardi v0.11.9/go.mod h1:Pr6Cj6Wsahw45myttaOEZeZ0LE7p1qzWmzgsBISkrNI=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-chef/chef v0.3.0 h1:pGWQmrk+PZsauxh893b0/myAFdCSCvt0tXRhu+LQJK8=
+github.com/go-chef/chef v0.3.0/go.mod h1:5J2BzvgKgC5QTujsyRzDB7ngZT23/YnpUDwBR1XQNq4=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,0 +1,9 @@
+pkg_name=chef-analyze
+pkg_origin=chef
+pkg_description="Chef Inventory analyzer command line interface (CLI)"
+pkg_maintainer="Chef Software Inc. <support@chef.io>"
+pkg_version="0.1.0"
+pkg_bin_dirs=(bin)
+pkg_deps=(core/glibc)
+pkg_scaffolding=core/scaffolding-go
+scaffolding_go_module=on

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ func main() {
 	})
 	if err != nil {
 		fmt.Println("Unable setup Chef client:", err)
+		os.Exit(1)
 	}
 
 	// List Nodes
@@ -51,16 +52,35 @@ func main() {
 
 	// Print out the list
 	fmt.Println("Nodes:")
-	fmt.Println(nodesList)
+	for nodeName, _ := range nodesList {
+		fmt.Println(nodeName)
+	}
 
 	// List Cookbooks
-	cookList, err := client.Cookbooks.List()
+	cookbookList, err := client.Cookbooks.List()
 	if err != nil {
 		fmt.Println("Unable to list cookbooks:", err)
 		os.Exit(1)
 	}
 
 	// Print out the list
-	fmt.Println("Cookbooks:")
-	fmt.Println(cookList)
+	fmt.Println("\nCookbooks:")
+	for cookbookName, cookbookVersions := range cookbookList {
+		versionsArray := cookbookVersionsAsArrayStrings(&cookbookVersions)
+		fmt.Printf("%s %v\n", cookbookName, versionsArray)
+	}
+}
+
+// TODO @afiune contribute back to the community repo, propose to add a function to the struct
+// that automatically extracts these values for convenience at:
+//
+// https://github.com/go-chef/chef/blob/master/cookbook.go#L28
+func cookbookVersionsAsArrayStrings(cookbookVersions *chef.CookbookVersions) []string {
+	rawVersions := make([]string, len(cookbookVersions.Versions))
+
+	for x, cookbookVersion := range cookbookVersions.Versions {
+		rawVersions[x] = cookbookVersion.Version
+	}
+
+	return rawVersions
 }

--- a/main.go
+++ b/main.go
@@ -9,22 +9,19 @@ import (
 	"github.com/go-chef/chef"
 )
 
-// TODO @afiune migrate these flags to use viper since it is our standard @Chef
-var (
-	clientName    string
-	clientKey     string
-	chefServerUrl string
-)
-
 func main() {
 	// TODO @afiune migrate these flags to use viper since it is our standard @Chef
+	var (
+		clientName    string
+		clientKey     string
+		chefServerUrl string
+	)
 	flag.StringVar(&clientName, "user", "", "Chef Infra Server API client username.")
 	flag.StringVar(&clientKey, "key", "", "Chef Infra Server API client key.")
 	flag.StringVar(&chefServerUrl, "chef_server_url", "", "Chef Infra Server URL.")
 	flag.Parse()
-
 	if clientName == "" || clientKey == "" || chefServerUrl == "" {
-		fmt.Println("One or more parameters missing. Required: -user USER -key KEY -chef_server_url URL")
+		fmt.Println("One or more parameters missing.\n\nRequired:\n\t-user USER\n\t-key KEY\n\t-chef_server_url URL")
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/go-chef/chef"
+)
+
+// TODO @afiune migrate these flags to use viper since it is our standard @Chef
+var (
+	clientName    string
+	clientKey     string
+	chefServerUrl string
+)
+
+func main() {
+	// TODO @afiune migrate these flags to use viper since it is our standard @Chef
+	flag.StringVar(&clientName, "user", "", "Chef Infra Server API client username.")
+	flag.StringVar(&clientKey, "key", "", "Chef Infra Server API client key.")
+	flag.StringVar(&chefServerUrl, "chef_server_url", "", "Chef Infra Server URL.")
+	flag.Parse()
+
+	if clientName == "" || clientKey == "" || chefServerUrl == "" {
+		fmt.Println("One or more parameters missing. Required: -user USER -key KEY -chef_server_url URL")
+		os.Exit(1)
+	}
+
+	// read a client key
+	key, err := ioutil.ReadFile(clientKey)
+	if err != nil {
+		fmt.Println("Couldn't read key pem:", err)
+		os.Exit(1)
+	}
+
+	// build a client
+	client, err := chef.NewClient(&chef.Config{
+		Name:    clientName,
+		Key:     string(key),
+		BaseURL: chefServerUrl,
+	})
+	if err != nil {
+		fmt.Println("Unable setup Chef client:", err)
+	}
+
+	// List Nodes
+	nodesList, err := client.Nodes.List()
+	if err != nil {
+		fmt.Println("Unable to list nodes:", err)
+		os.Exit(1)
+	}
+
+	// Print out the list
+	fmt.Println("Nodes:")
+	fmt.Println(nodesList)
+
+	// List Cookbooks
+	cookList, err := client.Cookbooks.List()
+	if err != nil {
+		fmt.Println("Unable to list cookbooks:", err)
+		os.Exit(1)
+	}
+
+	// Print out the list
+	fmt.Println("Cookbooks:")
+	fmt.Println(cookList)
+}


### PR DESCRIPTION
This PR is creating a very basic Go binary that leverages a couple of Chef Server
APIs, such endpoints are 1) Nodes list and 2) Cookbook lists. The way this PR
is implemented is only as an example of how can we use the Go Chef library:

- https://github.com/go-chef/chef

To test this PR you need to enter a studio and then run the following
commands:
```
$ hab studio enter
[1][default:/src:0]# build
[2][default:/src:0]# source results/last_build.env
[3][default:/src:0]# hab pkg install -b -f "results/${pkg_artifact}"
[4][default:/src:0]# chef-analyze -user afiune -key afiune.pem -chef_server_url "https://chef-server-acceptance.chef.co/organizations/chef-workstation/"
Nodes:

Cookbooks:
```

To cross-compile this binary you can use the studio helper:
```
$ hab studio enter
[1][default:/src:0]# build_cross_platform
Number of parallel builds: 3

-->    darwin/amd64: github.com/chef/chef-analyze
-->     linux/amd64: github.com/chef/chef-analyze
-->     windows/386: github.com/chef/chef-analyze
-->       linux/386: github.com/chef/chef-analyze
-->   windows/amd64: github.com/chef/chef-analyze
-->      darwin/386: github.com/chef/chef-analyze
[2][default:/src:0]# ll bin/
total 41036
-rwxr-xr-x 1 root root 6711428 Sep 16 23:39 chef-analyze_darwin_386
-rwxr-xr-x 1 root root 7509784 Sep 16 23:38 chef-analyze_darwin_amd64
-rwxr-xr-x 1 root root 6621190 Sep 16 23:38 chef-analyze_linux_386
-rwxr-xr-x 1 root root 7488900 Sep 16 23:37 chef-analyze_linux_amd64
-rwxr-xr-x 1 root root 6444032 Sep 16 23:38 chef-analyze_windows_386.exe
-rwxr-xr-x 1 root root 7233024 Sep 16 23:39 chef-analyze_windows_amd64.exe
```
If you are running on mac you can just run the command:
```
➜  chef-analyze git:(afiune/SPIKE) ✗ time bin/chef-analyze_darwin_386 -user afiune -key afiune.pem -chef_server_url "https://chef-server-acceptance.chef.co/organizations/chef-workstation/"
Nodes:
bar

Cookbooks:
foo [0.1.0]

bin/chef-analyze_darwin_386 -user afiune -key afiune.pem -chef_server_url   0.09s user 0.07s system 20% cpu 0.822 total
```
The speed of this command, compared to running `knife node list` and
`knife cookbook list` is abysmal! 
```
➜  chef-analyze git:(afiune/SPIKE) ✗ time knife node list
bar
knife node list  5.18s user 2.38s system 83% cpu 9.099 total
➜  chef-analyze git:(afiune/SPIKE) ✗ time knife cookbook list
foo   0.1.0
knife cookbook list  4.76s user 1.97s system 92% cpu 7.298 total
```

## Execution Time: Go Vs Ruby
| This Go binary  | Knife Ruby |
| ------------- | ------------- |
| `0.822s`  | `> 10s`  |

Issue: https://github.com/chef/chef-workstation/issues/497

Signed-off-by: Salim Afiune <afiune@chef.io>