### PR TITLE
Do not build Hab pkg for kernel2

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1,5 +1,2 @@
 [chef-infra-client]
-build_targets = [
-  "x86_64-linux",
-  "x86_64-linux-kernel2"
-]
+build_targets = [ "x86_64-linux" ]


### PR DESCRIPTION
The `core/scaffolding-go` is not yet building packages for linux kernel2.

Logs:
```
☁ Determining latest version of core/scaffolding-go in the 'stable' channel
  | ✗✗✗
  | ✗✗✗ Package not found.
  | ✗✗✗
  | chef-analyze: WARN: Could not find a suitable installed package for 'core/scaffolding-go'
  | chef-analyze: ERROR: Resolving 'core/scaffolding-go' failed, should this be built first?
```

Signed-off-by: Salim Afiune <afiune@chef.io>