### PR TITLE
Enable hab pkg promotions through Expeditor

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -40,6 +40,6 @@ promote:
     - stable
 
 subscriptions:
-  - workloads: project_promoted:{{agent_id}}:*
+  - workload: project_promoted:{{agent_id}}:*
     actions:
       - built_in:promote_habitat_packages

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -33,3 +33,13 @@ pipelines:
   - verify:
       description: Pull Request validation tests
   - habitat/build
+
+promote:
+  channels:
+    - unstable
+    - stable
+
+subscriptions:
+  - workloads: project_promoted:{{agent_id}}:*
+    actions:
+      - built_in:promote_habitat_packages


### PR DESCRIPTION
I think with this we will be able to do promotions in Slack like:
```
/expeditor promote chef/chef-analyze:master VERSION
```

![tenor-225779700](https://user-images.githubusercontent.com/5712253/66427234-c939f980-e9d0-11e9-893f-94e4e225994b.gif)

Signed-off-by: Salim Afiune <afiune@chef.io>