### PR TITLE
Adds an example report for cookbooks

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/go-chef/chef v0.3.0/go.mod h1:5J2BzvgKgC5QTujsyRzDB7ngZT23/YnpUDwBR1X
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
This adds a simple example of a cookbook oriented report:
```
➜  bin/chef-analyze_darwin_amd64 -user "afiune" -key ~/.chef/afiune.pem -chef_server_url 'https://chef-server.example.com/organizations/chef-workstation/'
                     Node Name   Chef Version   OS                OS Version
                           bar   <nil>          <nil>             <nil>
                   chef-load-6   13.2.28        mac_os_x          10.14.6
                  chef-load-40   12.5.54        mac_os_x          10.14.6
                kitchen-ubuntu   15.3.14        ubuntu            18.04
                  chef-load-52   13.1.0         ubuntu            18.04
                   chef-load-7   15.3.14        platform 14       <nil>
                   chef-load-9   15.3.14        ubuntu            18.04
                   chef-load-8   15.3.14        windows           6.3.9600
                  chef-load-50   15.3.14        platform 14       <nil>
                   chef-load-4   15.3.14        windows           6.3.9600
                  ubuntu-node1   15.3.14        ubuntu            18.04
                   chef-load-1   14.1.2         mac_os_x          10.14.6
                  chef-load-10   15.3.14        oracle            8.1.0


                 Cookbook Name   Version(s)
                           foo   0.3.0, 0.2.0, 0.1.0
```

In preparation for https://github.com/chef/chef-analyze/issues/16 / https://github.com/chef/chef-analyze/issues/17

Signed-off-by: Salim Afiune <afiune@chef.io>
