### PR TITLE
Fix the chef-analyze help command

### DIFF
--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -1,0 +1,18 @@
+package cmd
+
+//
+// The intend of this file is to have a single place where we can easily
+// visualize the list of all error messages that we present to users.
+//
+
+const (
+	MissingMinimumParametersErr = `
+  there are missing parameters for this tool to work, provide a credentials file:
+    --credentials string
+
+  or the following required flags:
+    --client_key string
+    --client_name string
+    --chef_server_url string
+`
+)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,9 +65,10 @@ func initConfig() {
 		if err == nil {
 			viper.SetConfigFile(credsFile)
 		} else {
-			if !hasMinimumParams() {
-				// throw error
-				fmt.Println("Error: ---")
+
+			if !hasMinimumParams() && !isHelpCommand() {
+				fmt.Printf("Error: %s\n", MissingMinimumParametersErr)
+				rootCmd.Usage()
 				os.Exit(-1)
 			}
 			//debug("Unable to file credentials:  %s", err.Error())
@@ -96,6 +97,15 @@ func flagString(name string) string {
 		return ""
 	}
 	return f.Value.String()
+}
+func isHelpCommand() bool {
+	if len(os.Args) <= 1 {
+		return false
+	}
+	if os.Args[1] == "help" {
+		return true
+	}
+	return false
 }
 
 // overrides the credentials from the viper bound flags


### PR DESCRIPTION
The cobra `OnInitialize` function will run for every single command on the
CLI, that includes the `help` command, but if a user is asking for help, we
should not throw and error, instead just print the usage 💯 

Now the user will see the following output:
```
$ chef-analyze help
Analyze your Chef inventory by generating reports to understand the effort
to upgrade to the latest version of the Chef tools, automatically fixing
violations and/or deprecations, and generating Effortless packages.

Usage:
  chef-analyze [command]

Available Commands:
  help        Help about any command
  report      Generate reports about your Chef inventory

Flags:
  -s, --chef_server_url string   Chef Infra Server URL
  -k, --client_key string        Chef Infra Server API client key
  -n, --client_name string       Chef Infra Server API client username
  -c, --credentials string       Chef credentials file (default $HOME/.chef/credentials)
  -h, --help                     help for chef-analyze
  -p, --profile string           Chef Infra Server URL (default "default")

Use "chef-analyze [command] --help" for more information about a command.
```

Also, actual commands that require parameters of a config file will have the following
error message:
```
 $ chef-analyze report cookbooks
Error:
  missing parameters for this tool to work, provide a credentials file:
    --credentials string

  or the following required flags:
    --client_key string
    --client_name string
    --chef_server_url string

Usage:
  chef-analyze [command]

Available Commands:
  help        Help about any command
  report      Generate reports about your Chef inventory

Flags:
  -s, --chef_server_url string   Chef Infra Server URL
  -k, --client_key string        Chef Infra Server API client key
  -n, --client_name string       Chef Infra Server API client username
  -c, --credentials string       Chef credentials file (default $HOME/.chef/credentials)
  -p, --profile string           Chef Infra Server URL (default "default")

Use "chef-analyze [command] --help" for more information about a command.
```
Signed-off-by: Salim Afiune <afiune@chef.io>