### PR TITLE
[bug-fix] Infinite loop on windows platforms

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,7 +3,7 @@ package config
 import (
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/BurntSushi/toml"
 	"github.com/pkg/errors"
@@ -161,10 +161,13 @@ func FindConfigFile(name string) (string, error) {
 
 	var previous string
 	for {
-		configFile := path.Join(cwd, DefaultChefDirectory, name)
+		configFile := filepath.Join(cwd, DefaultChefDirectory, name)
 		if configFile == previous {
 			break
 		}
+
+		//debug("searching config in: %s\n", configFile)
+
 		if _, err := os.Stat(configFile); err == nil {
 			// config file found
 			return configFile, nil
@@ -174,7 +177,7 @@ func FindConfigFile(name string) (string, error) {
 		// to stop the for loop from going in an infinite loop
 		previous = configFile
 		// go down the directory tree
-		cwd = path.Join(cwd, "..")
+		cwd = filepath.Join(cwd, "..")
 	}
 
 	// if we were unable to find the config file inside the current
@@ -185,7 +188,7 @@ func FindConfigFile(name string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "unable to detect home directory")
 	}
-	configFile := path.Join(home, DefaultChefDirectory, name)
+	configFile := filepath.Join(home, DefaultChefDirectory, name)
 	if _, err := os.Stat(configFile); err == nil {
 		// config file found
 		return configFile, nil


### PR DESCRIPTION
## Description
Before this change, we were using the Go core library `path` to join
filesystem paths, it worked in Unix systems but on Windows, we end up
in an infinite loop.

The fix is to use the Go core library `path/filepath`...

Signed-off-by: Salim Afiune <afiune@chef.io>

## Related Issue
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
