### PR TITLE
Bump Go module to 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chef/chef-analyze
 
-go 1.12
+go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1


### PR DESCRIPTION
As the Release notes say, we have to switch the version inside the `go.mod`:
>If your code uses modules and your go.mod files specifies a language version, be sure it is set to at least 1.13 to get access to these language changes. You can do this by editing the go.mod file directly, or you can run `go mod edit -go=1.13`.

https://golang.org/doc/go1.13#language

Signed-off-by: Salim Afiune <afiune@chef.io>
