### PR TITLE
Display code coverage message for 0% increase

### DIFF
--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -35,11 +35,17 @@ EOF
 }
 
 function code_coverage_table() {
-  if [ "$(is_coverage_degraded)" == "true" ]; then
-    echo "\\n :x: The code coverage decreased by $(coverage_decrease)% (**master** ${COVERAGE_MASTER}%)"
+  if [ "$COVERAGE_MASTER" == "$COVERAGE_PR" ]; then
+    echo "\\n :arrows_counterclockwise: This change neither increases nor decreases the code coverage. (**master ${COVERAGE_MASTER}%**)"
+    echo "\\n ## 0% Increase! :sweat_smile:"
+  elif [ "$(is_coverage_degraded)" == "true" ]; then
+    echo "\\n :x: The code coverage is decreased. (**master ${COVERAGE_MASTER}%**)"
+    echo "\\n ## $(coverage_decrease)% Decrease! :thinking:"
   else
-    echo "\\n :white_check_mark: The code coverage increased by $(coverage_increase)% (**master** ${COVERAGE_MASTER}%)"
+    echo "\\n :white_check_mark: The code coverage is increased. (**master ${COVERAGE_MASTER}%**)"
+    echo "\\n ## $(coverage_increase)% Increase! :rocket:"
   fi
+
   cat <<EOF
 \\n
 \\n :eyes: Read the <a href='$(buildkite_artifacts_url)'>uploaded HTML coverage report</a>
@@ -71,12 +77,20 @@ function buildkite_artifacts_url() {
 
 curl -H "Authorization: token $GITHUB_TOKEN" "$COMMENTS_URL" -d "$(post_data)" >/dev/null
 
-if [ "$(is_coverage_degraded)" == "true" ]; then
+if [ "$COVERAGE_MASTER" == "$COVERAGE_PR" ]; then
+  cat << EOF | buildkite-agent annotate --style "info"
+  This change neither increases nor decreases the code coverage from master. (${COVERAGE_MASTER}%)
+
+  Read the <a href="artifact://coverage/coverage.html">uploaded HTML coverage report</a>
+EOF
+elif [ "$(is_coverage_degraded)" == "true" ]; then
   cat << EOF | buildkite-agent annotate --style "error"
-  The code coverage is being degraded from ${COVERAGE_MASTER}% to ${COVERAGE_PR}%
+  The code coverage will decrease from ${COVERAGE_MASTER}% to ${COVERAGE_PR}%
 
   Take a look at the <a href="artifact://coverage/coverage.html">uploaded HTML coverage report</a>
 EOF
+  # @afiune this exit code enforces the code coverage to be increased or,
+  # at least, to be the same as master
   exit 7
 else
   cat << EOF | buildkite-agent annotate --style "success"

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,4 +1,3 @@
-# Documentation available at https://expeditor.chef.io/docs/getting-started/
 ---
 # The name we use for this project when interacting with Expeditor Slack App
 project:
@@ -30,6 +29,7 @@ merge_actions:
       only_if: built_in:bump_version
   - trigger_pipeline:code_coverage:
       ignore_labels:
+        - "Expeditor: Skip Code Coverage"
         - "Expeditor: Skip All"
 
 pipelines:


### PR DESCRIPTION
## Description
When there is a 0% increase, it means that the change is not modifying
any code or test, let us cover that case with a nice message.

See an example of this new message below: https://github.com/chef/chef-analyze/pull/45#issuecomment-548700316

Additionally, the pipeline will show the following information message:

![image](https://user-images.githubusercontent.com/5712253/68010752-15343300-fc4b-11e9-8de1-5f1ca10f45bf.png)

Finally, there is a new tag to ignore/skip the code coverage update on any PR merge,
the tag name is **"Expeditor: Skip Code Coverage"**.

![tenor-217408029](https://user-images.githubusercontent.com/5712253/68043349-b39bb500-fc9a-11e9-9b36-6b9166bac564.gif)

Signed-off-by: Salim Afiune <afiune@chef.io>
## Related Issue
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
