### PR TITLE
Fix Habitat builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,20 @@ ifeq ($(UNAME_S),Darwin)
 endif
 BINARY:=chef-analyze_$(PLATFORM)
 
+# If we are running make in our CI pipeline, default to our go build cmd
+ifeq ($(CI),true)
+default: go-build
+else
 default: patch_local_workstation_install
+endif
 
 patch_local_workstation_install: build_cross_platform override_binary
 
-build:
+hab-build:
 	hab pkg build .
+
+go-build:
+	go build
 
 override_binary:
 	ln -sf $(PWD)/bin/$(BINARY) /usr/local/bin/chef-analyze


### PR DESCRIPTION
## Description
The core/scaffolding-go has a feature that, if a Go project has a
`Makefile` inside the source directory (`/src`), it will execute `make`
to build the go binary. Since I added a `Makefile`, the pipeline has
been failing for a couple of days. This change detects if we are running in
our CI pipeline, and if so, changes the default make task to build the
go binary as the scaffolding does it.

Signed-off-by: Salim Afiune <afiune@chef.io>

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

- No Issue.
- Pipeline: https://buildkite.com/chef/chef-chef-analyze-master-habitat-build
- Core Scaffolding Docs: https://github.com/habitat-sh/core-plans/tree/master/scaffolding-go#scaffolding_go_build

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
