### PR TITLE
Make go-build the default make tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,9 @@ ifeq ($(UNAME_S),Darwin)
 endif
 BINARY:=chef-analyze_$(PLATFORM)
 
-# If we are running make in our CI pipeline, default to our go build cmd
-ifeq ($(CI),true)
 default: go-build
-else
-default: patch_local_workstation_install
-endif
 
-patch_local_workstation_install: build_cross_platform override_binary
+patch_local_workstation: build_cross_platform override_binary
 
 hab-build:
 	hab pkg build .

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ For details about the code coverage open the generated HTML report located at `c
 
 ### Patching a local Chef Workstation Install
 You can override the `chef-analyze` binary that comes inside your local Chef Workstation install by
-running `make` at the top level folder of this repository. Then just simply run `chef-analyze` or
-`chef analyze` to use the top-level chef wrapper.
+running `make patch_local_workstation` at the top level folder of this repository. Then just simply
+run `chef-analyze` or `chef analyze` to use the top-level chef wrapper.
 
 ## Contributing
 


### PR DESCRIPTION
It is better to make the `go-build` the default make task than adding all
the extra logic (headache) for running it differently in CI or Locally.

Signed-off-by: Salim Afiune <afiune@chef.io>