### PR TITLE
Only check for ChefDeprecations cops in Cookstyle

### DIFF
--- a/pkg/reporting/cookstyle.go
+++ b/pkg/reporting/cookstyle.go
@@ -94,7 +94,7 @@ func (ecr *CookstyleRunner) Run(workingDir string) (*CookstyleResult, error) {
 
 func NewCookstyleRunner() *CookstyleRunner {
 	return &CookstyleRunner{
-		Opts: []string{"--format", "json"},
+		Opts: []string{"--format", "json", "--only", "ChefDeprecations"},
 	}
 }
 

--- a/pkg/reporting/cookstyle_test.go
+++ b/pkg/reporting/cookstyle_test.go
@@ -66,7 +66,7 @@ func TestCookstyleRunnerWithBinstubs(t *testing.T) {
 
 	runner := subject.NewCookstyleRunner()
 	assert.Equal(t,
-		[]string{"--format", "json"}, runner.Opts,
+		[]string{"--format", "json", "--only", "ChefDeprecations"}, runner.Opts,
 		"default cookstyle options need to be updated",
 	)
 


### PR DESCRIPTION
If our goal is allow for upgrades then the only cops that are 100%
required are the ChefDeprecations cops. We should skip all the others.
Perhaps a flag later on to enable all Chef cops, but this is better for
now.

Signed-off-by: Tim Smith <tsmith@chef.io>