### PR TITLE
integration:(fix-test) catch errors on buildkite

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -36,7 +36,7 @@ steps:
           privileged: true
   - label: ":windows: go-integration"
     command:
-      - hab studio run "./scripts/integration_tests.ps1"
+      - hab studio run './scripts/integration_tests.ps1; Exit \$LastExitCode'
     expeditor:
       executor:
         windows:

--- a/integration/credentials_test.go
+++ b/integration/credentials_test.go
@@ -47,19 +47,19 @@ func createCredentialsConfig() string {
 	}
 
 	creds := []byte(`[default]
-client_name = "` + DefaultChefServerUser + `"
-client_key = "` + defaultPem + `"
-chef_server_url = "http://localhost/organizations/` + DefaultChefServerOrganization + `"
+client_name = '` + DefaultChefServerUser + `'
+client_key = '` + defaultPem + `'
+chef_server_url = 'http://localhost/organizations/` + DefaultChefServerOrganization + `'
 
 [dev]
-client_name = "dev"
-client_key = "` + devPem + `"
-chef_server_url = "http://localhost/organizations/dev"
+client_name = 'dev'
+client_key = '` + devPem + `'
+chef_server_url = 'http://localhost/organizations/dev'
 
 [empty]
-client_name = "empty"
-client_key = "` + emptyPem + `"
-chef_server_url = "http://localhost/organizations/empty"
+client_name = 'empty'
+client_key = '` + emptyPem + `'
+chef_server_url = 'http://localhost/organizations/empty'
 `)
 	err = ioutil.WriteFile(credsFile, creds, 0644)
 	if err != nil {

--- a/integration/framework_test.go
+++ b/integration/framework_test.go
@@ -91,16 +91,14 @@ func ChefAnalyzeWithHome(dir string, args ...string) (bytes.Buffer, bytes.Buffer
 	return runChefAnalyzeCmd(dir, args...)
 }
 
-func runChefAnalyzeCmd(home string, args ...string) (stdout bytes.Buffer, stderr bytes.Buffer, exitcode int) {
+func runChefAnalyzeCmd(workingDir string, args ...string) (stdout bytes.Buffer, stderr bytes.Buffer, exitcode int) {
 	cmd := exec.Command(findChefAnalyzeBinary(), args...)
 	cmd.Env = os.Environ()
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	if len(home) != 0 {
-		cmd.Env = append(os.Environ(),
-			fmt.Sprintf("HOME=%s", home),
-		)
+	if len(workingDir) != 0 {
+		cmd.Dir = workingDir
 	}
 
 	exitcode = 0

--- a/scripts/integration_tests.ps1
+++ b/scripts/integration_tests.ps1
@@ -1,9 +1,18 @@
+# Stop script execution when a non-terminating error occurs
+$ErrorActionPreference = "Stop"
+
+# Enable the use of Go vendor/ directory
+$Env:GOFLAGS = "-mod=vendor"
+
 ECHO "-- Installing Golang"
 hab pkg install -b afiune/go
+If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
 ECHO "-- Building chef-analyze EXE"
 go build -o bin\chef-analyze_windows.exe
+If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
 ECHO "-- Running integration tests (github.com/chef/chef-analyze/integration)"
 $Env:CHEF_ANALYZE_BIN = (Get-PSDrive Habitat).Root + "\src\bin\chef-analyze_windows.exe"
 go test github.com/chef/chef-analyze/integration -v
+If ($LastExitCode -ne 0) { Exit $LastExitCode }


### PR DESCRIPTION
Currently, if there are failures on our integration tests inside buildkite we
don't see them since they are not propagated to the job status, this PR is
the fix to catch errors and mark the pipeline red 🔴 

The reason this is happening is because Hab Studios are not propagating
the errors, the way to workaround this was to add an `Exit` statement after
the execution of the PowerShell script.

Signed-off-by: Salim Afiune <afiune@chef.io>