### PR TITLE
Run the ChefCorrectness cops in Cookstyle

### DIFF
--- a/pkg/reporting/cookstyle.go
+++ b/pkg/reporting/cookstyle.go
@@ -94,7 +94,7 @@ func (ecr *CookstyleRunner) Run(workingDir string) (*CookstyleResult, error) {
 
 func NewCookstyleRunner() *CookstyleRunner {
 	return &CookstyleRunner{
-		Opts: []string{"--format", "json", "--only", "ChefDeprecations"},
+		Opts: []string{"--format", "json", "--only", "ChefDeprecations,ChefCorrectness"},
 	}
 }
 

--- a/pkg/reporting/cookstyle_test.go
+++ b/pkg/reporting/cookstyle_test.go
@@ -66,7 +66,7 @@ func TestCookstyleRunnerWithBinstubs(t *testing.T) {
 
 	runner := subject.NewCookstyleRunner()
 	assert.Equal(t,
-		[]string{"--format", "json", "--only", "ChefDeprecations"}, runner.Opts,
+		[]string{"--format", "json", "--only", "ChefDeprecations,ChefCorrectness"}, runner.Opts,
 		"default cookstyle options need to be updated",
 	)
 


### PR DESCRIPTION
Now that 5.15 is out everything in ChefCorrectness should be corrected
before upgrading chef-client releases.

Signed-off-by: Tim Smith <tsmith@chef.io>