### PR TITLE
feat:(store-reports) txt/csv nodes reports

### DIFF
--- a/cmd/report.go
+++ b/cmd/report.go
@@ -156,6 +156,7 @@ provided when the report is generated.
 				return err
 			}
 
+			fmt.Println("Analyzing nodes...")
 			report, err := reporting.Nodes(chefClient.Search)
 			if err != nil {
 				return err

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -106,7 +106,7 @@ provided when the report is generated.
 
 			fmt.Println(formattedSummary.Report)
 
-			switch cookbooksFlags.format {
+			switch reportsFlags.format {
 			case "csv":
 				ext = CsvExt
 				results = formatter.MakeCookbooksReportCSV(cookbooksState)
@@ -170,7 +170,7 @@ provided when the report is generated.
 
 			fmt.Println(formattedSummary.Report)
 
-			switch nodesFlags.format {
+			switch reportsFlags.format {
 			case "csv":
 				ext = CsvExt
 				results = formatter.MakeNodesReportCSV(report)
@@ -195,14 +195,21 @@ provided when the report is generated.
 		onlyUnused   bool
 		runCookstyle bool
 		workers      int
-		format       string
 	}
-	nodesFlags struct {
+	reportsFlags struct {
 		format string
 	}
 )
 
 func init() {
+	// global report commands flags
+	reportCmd.PersistentFlags().StringVarP(
+		&reportsFlags.format,
+		"format", "f", "txt",
+		"output format: txt is human readable, csv is machine readable",
+	)
+
+	// cookbooks cmd flags
 	reportCookbooksCmd.PersistentFlags().IntVarP(
 		&cookbooksFlags.workers,
 		"workers", "w", 50,
@@ -218,20 +225,10 @@ func init() {
 		"verify-upgrade", "v", false,
 		"verify the upgrade compatibility of every cookbook",
 	)
-	reportCookbooksCmd.PersistentFlags().StringVarP(
-		&cookbooksFlags.format,
-		"format", "f", "txt",
-		"output format: txt is human readable, csv is machine readable",
-	)
 	// adds the cookbooks command as a sub-command of the report command
 	// => chef-analyze report cookbooks
 	reportCmd.AddCommand(reportCookbooksCmd)
 
-	reportCmd.PersistentFlags().StringVarP(
-		&nodesFlags.format,
-		"format", "f", "txt",
-		"output format: txt is human readable, csv is machine readable",
-	)
 	// adds the nodes command as a sub-command of the report command
 	// => chef-analyze report nodes
 	reportCmd.AddCommand(reportNodesCmd)

--- a/pkg/formatter/csv.go
+++ b/pkg/formatter/csv.go
@@ -89,3 +89,38 @@ func MakeCookbooksReportCSV(state *reporting.CookbooksStatus) *FormattedResult {
 	csvWriter.Flush()
 	return &FormattedResult{strBuilder.String(), errBuilder.String()}
 }
+
+func MakeNodesReportCSV(records []*reporting.NodeReportItem) *FormattedResult {
+	var (
+		strBuilder strings.Builder
+		errBuilder strings.Builder
+		csvWriter  = csv.NewWriter(&strBuilder)
+	)
+
+	if len(records) == 0 {
+		return &FormattedResult{"", ""}
+	}
+
+	tableHeaders := []string{"Node Name", "Chef Version", "Operating System", "Cookbooks"}
+	csvWriter.Write(tableHeaders)
+
+	for _, record := range records {
+		var (
+			cookbooksString = "None"
+			cookbooksList   = record.CookbooksList()
+		)
+		if len(cookbooksList) != 0 {
+			cookbooksString = strings.Join(cookbooksList, " ")
+		}
+
+		csvWriter.Write([]string{
+			record.Name,
+			record.ChefVersion,
+			record.OSVersionPretty(),
+			cookbooksString,
+		})
+	}
+
+	csvWriter.Flush()
+	return &FormattedResult{strBuilder.String(), errBuilder.String()}
+}

--- a/pkg/formatter/formatter_internal_test.go
+++ b/pkg/formatter/formatter_internal_test.go
@@ -17,27 +17,23 @@
 
 package formatter
 
-type FormattedResult struct {
-	Report string
-	Errors string
-}
+import (
+	"testing"
 
-const (
-	emptyValuePlaceholder   = "-"
-	unknownValuePlaceholder = "unknown"
+	"github.com/stretchr/testify/assert"
 )
 
-func stringOrEmptyPlaceholder(s string) string {
-	return stringOrPlaceholder(s, emptyValuePlaceholder)
+func TestStringOrEmptyPlaceholder(t *testing.T) {
+	assert.Equal(t, "-", stringOrEmptyPlaceholder(""))
+	assert.Equal(t, "foo", stringOrEmptyPlaceholder("foo"))
 }
 
-func stringOrUnknownPlaceholder(s string) string {
-	return stringOrPlaceholder(s, unknownValuePlaceholder)
+func TestStringOrUnknownPlaceholder(t *testing.T) {
+	assert.Equal(t, "unknown", stringOrUnknownPlaceholder(""))
+	assert.Equal(t, "foo", stringOrUnknownPlaceholder("foo"))
 }
 
-func stringOrPlaceholder(s, placeholder string) string {
-	if len(s) == 0 {
-		return placeholder
-	}
-	return s
+func TestStringOrPlaceholder(t *testing.T) {
+	assert.Equal(t, "placeholder", stringOrPlaceholder("", "placeholder"))
+	assert.Equal(t, "foo", stringOrPlaceholder("foo", "placeholder"))
 }

--- a/pkg/formatter/table_test.go
+++ b/pkg/formatter/table_test.go
@@ -25,62 +25,6 @@ import (
 	"github.com/chef/chef-analyze/pkg/reporting"
 )
 
-func TestNodeReportItemToArray_Nil(t *testing.T) {
-	expected := []string{"-", "-", "-", "-"}
-	assert.Equal(t, expected, subject.NodeReportItemToArray(nil))
-}
-
-func TestNodeReportItemToArray_valid(t *testing.T) {
-	cbv := reporting.CookbookVersion{Name: "name", Version: "version"}
-	nri := reporting.NodeReportItem{
-		Name:             "name",
-		ChefVersion:      "16.01",
-		OS:               "os",
-		OSVersion:        "1.0",
-		CookbookVersions: []reporting.CookbookVersion{cbv},
-	}
-	expected := []string{"name", "16.01", "os v1.0", "name(version)"}
-	assert.Equal(t, expected, subject.NodeReportItemToArray(&nri))
-}
-
-func TestNodeReportItemToArray_noOS(t *testing.T) {
-	cbv := reporting.CookbookVersion{Name: "name", Version: "version"}
-	nri := reporting.NodeReportItem{
-		Name:             "name",
-		ChefVersion:      "16.01",
-		OS:               "",
-		OSVersion:        "",
-		CookbookVersions: []reporting.CookbookVersion{cbv},
-	}
-	expected := []string{"name", "16.01", "-", "name(version)"}
-	assert.Equal(t, expected, subject.NodeReportItemToArray(&nri))
-}
-
-func TestNodeReportItemToArray_noCookbooks(t *testing.T) {
-	nri := reporting.NodeReportItem{
-		Name:             "name",
-		ChefVersion:      "16.01",
-		OS:               "os",
-		OSVersion:        "1.0",
-		CookbookVersions: []reporting.CookbookVersion{},
-	}
-	expected := []string{"name", "16.01", "os v1.0", "-"}
-	assert.Equal(t, expected, subject.NodeReportItemToArray(&nri))
-}
-
-func TestNodeReportItemToArray_noChefVersion(t *testing.T) {
-	cbv := reporting.CookbookVersion{Name: "name", Version: "version"}
-	nri := reporting.NodeReportItem{
-		Name:             "name",
-		ChefVersion:      "",
-		OS:               "os",
-		OSVersion:        "1.0",
-		CookbookVersions: []reporting.CookbookVersion{cbv},
-	}
-	expected := []string{"name", "-", "os v1.0", "name(version)"}
-	assert.Equal(t, expected, subject.NodeReportItemToArray(&nri))
-}
-
 func TestNodesReportSummary_Nil(t *testing.T) {
 	expected := subject.FormattedResult{"No nodes found to analyze.", ""}
 	assert.Equal(t, expected, subject.NodesReportSummary(nil))
@@ -140,9 +84,6 @@ func TestNodesReportSummary_withRecords(t *testing.T) {
 		"abc-2",
 		"15.4",
 		"os v1.0",
-		"cookbook1(0.3.0)",
-		"cool(0.1.0)",
-		"awesome(1.2.3)",
 		"13.1.20",
 	}
 	for _, s := range listOfStringTheReportMustHave {

--- a/pkg/formatter/txt.go
+++ b/pkg/formatter/txt.go
@@ -75,3 +75,37 @@ func MakeCookbooksReportTXT(state *reporting.CookbooksStatus) *FormattedResult {
 	}
 	return &FormattedResult{strBuilder.String(), errorBuilder.String()}
 }
+
+func MakeNodesReportTXT(records []*reporting.NodeReportItem) *FormattedResult {
+	var (
+		errorBuilder strings.Builder
+		strBuilder   strings.Builder
+	)
+
+	if len(records) == 0 {
+		// nothing to do
+		return &FormattedResult{"", ""}
+	}
+
+	for _, record := range records {
+		strBuilder.WriteString(fmt.Sprintf("> Node: %s\n", record.Name))
+		strBuilder.WriteString(
+			fmt.Sprintf("  Chef Version: %s\n",
+				stringOrUnknownPlaceholder(record.ChefVersion)),
+		)
+		strBuilder.WriteString(
+			fmt.Sprintf("  Operating System: %s\n",
+				stringOrUnknownPlaceholder(record.OSVersionPretty())),
+		)
+
+		if len(record.CookbooksList()) == 0 {
+			strBuilder.WriteString("  Cookbooks Applied: none\n")
+		} else {
+			strBuilder.WriteString("  Cookbooks Applied: ")
+			strBuilder.WriteString(strings.Join(record.CookbooksList(), ", "))
+			strBuilder.WriteString("\n")
+		}
+	}
+
+	return &FormattedResult{strBuilder.String(), errorBuilder.String()}
+}

--- a/pkg/formatter/txt_test.go
+++ b/pkg/formatter/txt_test.go
@@ -97,3 +97,53 @@ func TestMakeCookbooksReportTXT_ErrorReport(t *testing.T) {
 	assert.Equal(t, lines[2], " - our-cookbook (1.2): cookstyle error")
 	assert.Equal(t, lines[3], "")
 }
+
+func TestMakeNodesReportTXT_Nil(t *testing.T) {
+	assert.Equal(t,
+		&subject.FormattedResult{Report: "", Errors: ""},
+		subject.MakeNodesReportTXT(nil))
+}
+
+func TestMakeNodesReportTXT_Empty(t *testing.T) {
+	assert.Equal(t,
+		&subject.FormattedResult{Report: "", Errors: ""},
+		subject.MakeNodesReportTXT([]*reporting.NodeReportItem{}))
+}
+
+func TestMakeNodesReportTXT_WithRecords(t *testing.T) {
+	nodesReport := []*reporting.NodeReportItem{
+		&reporting.NodeReportItem{Name: "node1", ChefVersion: "12.22", OS: "windows", OSVersion: "10.1",
+			CookbookVersions: []reporting.CookbookVersion{
+				reporting.CookbookVersion{Name: "mycookbook", Version: "1.0"}},
+		},
+		&reporting.NodeReportItem{Name: "node2", ChefVersion: "13.11", OS: "", OSVersion: "",
+			CookbookVersions: []reporting.CookbookVersion{
+				reporting.CookbookVersion{Name: "mycookbook", Version: "1.0"},
+				reporting.CookbookVersion{Name: "test", Version: "9.9"},
+			},
+		},
+		&reporting.NodeReportItem{Name: "node3", ChefVersion: "15.00", OS: "ubuntu", OSVersion: "16.04",
+			CookbookVersions: nil},
+	}
+
+	var (
+		actual         = subject.MakeNodesReportTXT(nodesReport)
+		lines          = strings.Split(actual.Report, "\n")
+		expectedReport = `> Node: node1
+  Chef Version: 12.22
+  Operating System: windows v10.1
+  Cookbooks Applied: mycookbook(1.0)
+> Node: node2
+  Chef Version: 13.11
+  Operating System: unknown
+  Cookbooks Applied: mycookbook(1.0), test(9.9)
+> Node: node3
+  Chef Version: 15.00
+  Operating System: ubuntu v16.04
+  Cookbooks Applied: none
+`
+	)
+	if assert.Equal(t, 13, len(lines)) {
+		assert.Equal(t, expectedReport, actual.Report)
+	}
+}

--- a/pkg/reporting/cookbooks_test.go
+++ b/pkg/reporting/cookbooks_test.go
@@ -52,6 +52,15 @@ func TestCookbooksRecordCorrectableAndOffenses(t *testing.T) {
 	assert.Equal(t, 5, csr.NumOffenses())
 }
 
+func TestCookbooksRecordNumNodesAffected(t *testing.T) {
+	rec := subject.CookbookRecord{}
+	assert.Equal(t, 0, rec.NumNodesAffected())
+	rec = subject.CookbookRecord{Nodes: []string{}}
+	assert.Equal(t, 0, rec.NumNodesAffected())
+	rec = subject.CookbookRecord{Nodes: []string{"a", "b", "c"}}
+	assert.Equal(t, 3, rec.NumNodesAffected())
+}
+
 func TestCookbooksEmpty(t *testing.T) {
 	c, err := subject.NewCookbooks(
 		newMockCookbook(chef.CookbookListResult{}, nil, nil),

--- a/pkg/reporting/nodes.go
+++ b/pkg/reporting/nodes.go
@@ -39,11 +39,27 @@ type NodeReportItem struct {
 	CookbookVersions []CookbookVersion
 }
 
-// NOTE - we no longer need cfg. I'm not sure that this is best - I like having a single
-//        cfg which includes the client, but did not want to create a full mock interface for
-//        chef.client here - that belongs in go-chef, where it can be maintained alongside
-//        any interface changes that originate there.
-func Nodes(cfg *Reporting, searcher SearchInterface) ([]*NodeReportItem, error) {
+func (nri *NodeReportItem) OSVersionPretty() string {
+	// this data seems to be all or none,
+	// you'll have both OS/Version fields, or neither.
+	if nri.OS != "" {
+		return fmt.Sprintf("%s v%s", nri.OS, nri.OSVersion)
+	}
+
+	return ""
+}
+
+func (nri *NodeReportItem) CookbooksList() []string {
+	var cookbooks = make([]string, 0, len(nri.CookbookVersions))
+
+	for _, v := range nri.CookbookVersions {
+		cookbooks = append(cookbooks, v.String())
+	}
+
+	return cookbooks
+}
+
+func Nodes(searcher SearchInterface) ([]*NodeReportItem, error) {
 	var (
 		query = map[string]interface{}{
 			"name":         []string{"name"},


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Stores nodes report to disk.

![tenor-240351149](https://user-images.githubusercontent.com/5712253/70799183-3a1ed880-1da9-11ea-98b0-e8aee3dfa2a9.gif)

### New Nodes Output
```
$ chef-analyze report nodes
Analyzing nodes...

-- REPORT SUMMARY --

    Node Name      Chef Version   Operating System    Cookbooks
-----------------+--------------+-------------------+------------
  bar              -              -                           0
  chef-load-6      13.2.28        mac_os_x v10.14.6           0
  chef-load-40     12.5.54        mac_os_x v10.14.6           0
  kitchen-ubuntu   15.3.14        ubuntu v18.04               0
  chef-load-52     13.1.0         ubuntu v18.04               0
  chef-load-7      15.3.14        platform 14 v               0
  chef-load-9      15.3.14        ubuntu v18.04               0
  chef-load-8      15.3.14        windows v6.3.9600           0
  chef-load-50     15.3.14        platform 14 v               0
  chef-load-4      15.3.14        windows v6.3.9600           0
  ubuntu-node1     15.3.14        ubuntu v18.04               0
  chef-load-1      14.1.2         mac_os_x v10.14.6           0
  chef-load-10     15.3.14        oracle v8.1.0               0

Nodes report saved to .analyze-cache/reports/nodes-20191213124741.txt
```

Additionally, I have moved the `--format` flag to be global for every report
command since now both commands, `report cookbooks` and `report nodes`
have the ability to store reports on disk with different formats.

Signed-off-by: Salim Afiune <afiune@chef.io>

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef-analyze/issues/103

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
