### PR TITLE
Verifying multiple rows output data in every cell

### DIFF
--- a/pkg/formatter/csv.go
+++ b/pkg/formatter/csv.go
@@ -25,6 +25,7 @@ import (
 	"github.com/chef/chef-analyze/pkg/reporting"
 )
 
+// MakeCookbooksReportCSV generates a CSV formatted cookbooks report
 func MakeCookbooksReportCSV(state *reporting.CookbooksStatus) *FormattedResult {
 	var (
 		strBuilder strings.Builder
@@ -90,6 +91,7 @@ func MakeCookbooksReportCSV(state *reporting.CookbooksStatus) *FormattedResult {
 	return &FormattedResult{strBuilder.String(), errBuilder.String()}
 }
 
+// MakeNodesReportCSV generates a CSV formatted nodes report
 func MakeNodesReportCSV(records []*reporting.NodeReportItem) *FormattedResult {
 	var (
 		strBuilder strings.Builder

--- a/pkg/formatter/csv_test.go
+++ b/pkg/formatter/csv_test.go
@@ -125,9 +125,9 @@ func TestMakeCookbooksReportCSV_WithMultipleRecords(t *testing.T) {
 	lines := strings.Split(actual.Report, "\n")
 	assert.Equal(t, 5, len(lines))
 	assert.Equal(t, "Cookbook Name,Version,File,Offense,Automatically Correctable,Message,Nodes", lines[0])
-	assert.Equal(t, "my-cookbook,1.0,/path/to/file.rb,ChefDeprecations/Blah,Y,some description,node-1 node-2", lines[1])
-	assert.Equal(t, "my-cookbook,1.0,/path/to/other_file.rb,ChefDeprecations/Blah1,Y,some description1,node-1 node-2", lines[2])
-	assert.Equal(t, "my-cookbook,1.0,/path/to/other_file.rb,ChefDeprecations/Blah2,N,some description2,node-1 node-2", lines[3])
+	assert.Contains(t, lines, "my-cookbook,1.0,/path/to/file.rb,ChefDeprecations/Blah,Y,some description,node-1 node-2")
+	assert.Contains(t, lines, "my-cookbook,1.0,/path/to/other_file.rb,ChefDeprecations/Blah1,Y,some description1,node-1 node-2")
+	assert.Contains(t, lines, "my-cookbook,1.0,/path/to/other_file.rb,ChefDeprecations/Blah2,N,some description2,node-1 node-2")
 	assert.Equal(t, "", lines[4])
 }
 
@@ -181,9 +181,9 @@ func TestMakeNodesReportCSV_WithRecords(t *testing.T) {
 	lines := strings.Split(subject.MakeNodesReportCSV(nodesReport).Report, "\n")
 	if assert.Equal(t, 5, len(lines)) {
 		assert.Equal(t, "Node Name,Chef Version,Operating System,Cookbooks", lines[0])
-		assert.Equal(t, "node1,12.22,windows v10.1,mycookbook(1.0)", lines[1])
-		assert.Equal(t, "node2,13.11,,mycookbook(1.0) test(9.9)", lines[2])
-		assert.Equal(t, "node3,15.00,ubuntu v16.04,None", lines[3])
+		assert.Contains(t, lines, "node1,12.22,windows v10.1,mycookbook(1.0)")
+		assert.Contains(t, lines, "node2,13.11,,mycookbook(1.0) test(9.9)")
+		assert.Contains(t, lines, "node3,15.00,ubuntu v16.04,None")
 		assert.Equal(t, "", lines[4])
 	}
 }
@@ -205,7 +205,7 @@ func TestMakeNodesReportCSV_WithMultipleNodesAndCookbooks(t *testing.T) {
 		&reporting.NodeReportItem{Name: "node1", ChefVersion: "15.2", OS: "windows", OSVersion: "10.1",
 			CookbookVersions: []reporting.CookbookVersion{},
 		},
-		&reporting.NodeReportItem{Name: "node2", ChefVersion: "13.11", OS: "", OSVersion: "",
+		&reporting.NodeReportItem{Name: "node2", ChefVersion: "13.11", OS: "macos", OSVersion: "15",
 			CookbookVersions: []reporting.CookbookVersion{
 				reporting.CookbookVersion{Name: "mycookbook", Version: "1.0"},
 				reporting.CookbookVersion{Name: "test", Version: "9.9"},
@@ -218,9 +218,11 @@ func TestMakeNodesReportCSV_WithMultipleNodesAndCookbooks(t *testing.T) {
 	lines := strings.Split(subject.MakeNodesReportCSV(nodesReport).Report, "\n")
 	if assert.Equal(t, 7, len(lines)) {
 		assert.Equal(t, "Node Name,Chef Version,Operating System,Cookbooks", lines[0])
-		assert.Equal(t, "node1,12.22,windows v10.1,mycookbook1(1.0) mycookbook1(2.0)", lines[1])
-		assert.Equal(t, "node1,13.10,windows v10.1,mycookbook1(1.0) mycookbook1(2.0)", lines[2])
-		assert.Equal(t, "node3,15.00,ubuntu v16.04,None", lines[3])
-		assert.Equal(t, "", lines[4])
+		assert.Contains(t, lines, "node1,12.22,windows v10.1,mycookbook1(1.0) mycookbook1(2.0)")
+		assert.Contains(t, lines, "node1,13.10,windows v10.1,mycookbook1(1.0) mycookbook1(2.0)")
+		assert.Contains(t, lines, "node1,15.2,windows v10.1,None")
+		assert.Contains(t, lines, "node2,13.11,macos v15,mycookbook(1.0) test(9.9)")
+		assert.Contains(t, lines, "node3,15.00,ubuntu v16.04,None")
+		assert.Equal(t, "", lines[6])
 	}
 }


### PR DESCRIPTION
## Description
I had [a card](https://github.com/chef/chef-analyze/issues/88) to convert from my old 'fancy' csv outformatter that tried to not repeat data in columns when it was the same in the row above (made data appear to cascade down and to the right). It was a dumb thing to do - thats not how CSV works. Someone already fixed this issue for me so I just added a few tests and fixed a few warnings. Thanks @afiune and @marcparadise !

## Related Issue
Fixes https://github.com/chef/chef-analyze/issues/88

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
