### PR TITLE
unit:(tests) mock home dir as temp dir

### DIFF
--- a/pkg/reporting/chef_client_test.go
+++ b/pkg/reporting/chef_client_test.go
@@ -26,8 +26,7 @@ import (
 )
 
 func TestNewChefClientWithDefaults(t *testing.T) {
-	createCredentialsConfig(t)
-	defer os.RemoveAll(".chef") // clean up
+	defer os.RemoveAll(createCredentialsConfig(t))
 	cfg, err := subject.NewDefault()
 	if assert.Nil(t, err) {
 		client, err := subject.NewChefClient(&cfg)
@@ -46,8 +45,7 @@ func TestNewChefClientWithouAnySettings(t *testing.T) {
 }
 
 func TestNewChefClientCredsWithEmptyKey(t *testing.T) {
-	createCredentialsConfig(t)
-	defer os.RemoveAll(".chef") // clean up
+	defer os.RemoveAll(createCredentialsConfig(t))
 
 	cfg, err := subject.NewDefault()
 	if assert.Nil(t, err) {

--- a/pkg/reporting/client_test.go
+++ b/pkg/reporting/client_test.go
@@ -18,6 +18,9 @@ package reporting_test
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 
 	chef "github.com/chef/go-chef"
 )
@@ -45,12 +48,13 @@ func (cm CookbookMock) ListAvailableVersions(limit string) (chef.CookbookListRes
 }
 
 func (cm CookbookMock) DownloadTo(name, version, localDir string) error {
-	// TODO @afiune this will create the mocked local directory so that we can run cookstyle
-	//dirToMock := filepath.Join(localDir, fmt.Sprintf("%s-%s", name, version))
-	//err := os.MkdirAll(dirToMock, os.ModePerm)
-	//if err != nil {
-	//panic(err)
-	//}
+	var (
+		dirToMock = filepath.Join(localDir, fmt.Sprintf("%s-%s", name, version))
+		err       = os.MkdirAll(dirToMock, os.ModePerm)
+	)
+	if err != nil {
+		panic(err)
+	}
 	return cm.desiredDownloadError
 }
 

--- a/pkg/reporting/cookbooks_test.go
+++ b/pkg/reporting/cookbooks_test.go
@@ -216,6 +216,7 @@ func TestCookbooksNotUsedDisplayOnlyUnused(t *testing.T) {
 func TestCookbooks(t *testing.T) {
 	savedPath := setupBinstubsDir()
 	defer os.Setenv("PATH", savedPath)
+	defer os.RemoveAll(createConfigToml(t))
 
 	cookbookList := chef.CookbookListResult{
 		"foo": chef.CookbookVersions{
@@ -257,9 +258,8 @@ func TestCookbooks(t *testing.T) {
 				default:
 					t.Fatal("unexpected cookbook name")
 				}
-				// TODO @afiune uncomment when CookbookMock DownloadTo() creates a local dir
-				//assert.Emptyf(t, rec.Errors(),
-				//"there should not be any errors for %s-%s", rec.Name, rec.Version)
+				assert.Emptyf(t, rec.Errors(),
+					"there should not be any errors for %s-%s", rec.Name, rec.Version)
 			}
 
 			assert.Equal(t, 3, foo, "unexpected number of cookbooks foo")
@@ -317,6 +317,7 @@ func TestCookbooks_NoneAvailable(t *testing.T) {
 func TestCookbooks_DownloadErrors(t *testing.T) {
 	savedPath := setupBinstubsDir()
 	defer os.Setenv("PATH", savedPath)
+	defer os.RemoveAll(createConfigToml(t))
 
 	cookbookList := chef.CookbookListResult{
 		"foo": chef.CookbookVersions{
@@ -374,8 +375,7 @@ func TestCookbooks_UsageStatErrors(t *testing.T) {
 			for _, rec := range c.Records {
 				assert.NoError(t, rec.DownloadError, "unexpected DownloadError")
 				assert.EqualError(t, rec.UsageLookupError, "unable to get cookbook usage information: lookup error")
-				// TODO cookstyle returns error since we don't actually download a cookbook
-				// assert.NoError(t, rec.CookstyleError, "unexpected UsageLookupError")
+				assert.NoError(t, rec.CookstyleError, "unexpected UsageLookupError")
 			}
 		}
 	}

--- a/pkg/reporting/cookstyle_test.go
+++ b/pkg/reporting/cookstyle_test.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,7 +65,9 @@ func TestCookstyleRunnerWithBinstubs(t *testing.T) {
 
 	runner := subject.NewCookstyleRunner()
 	assert.Equal(t,
-		[]string{"--format", "json", "--only", "ChefDeprecations,ChefCorrectness"}, runner.Opts,
+		[]string{"--format", "json",
+			"--only", "ChefDeprecations,ChefCorrectness"},
+		runner.Opts,
 		"default cookstyle options need to be updated",
 	)
 
@@ -108,31 +109,4 @@ func TestCookstyleRunnerWithBinstubs(t *testing.T) {
 			"wrong Stderr, check either the binstub or the Go code for validation",
 		)
 	}
-}
-
-// returns the binstubs/ directory path
-func binstubsDir() string {
-	pwd, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-
-	return filepath.Join(pwd, "..", "..", "binstubs")
-}
-
-// setups up the binstubs directory at the front of the PATH environment
-// environment and returns the previous value so that callers can set
-// it back to its original value
-//
-// example:
-//
-// ```go
-// savedPath := setupBinstubsDir()
-// defer os.Setenv("PATH", savedPath)
-// ```
-func setupBinstubsDir() string {
-	pathEnv := os.Getenv("PATH")
-	newPathEnv := binstubsDir() + ":" + pathEnv
-	os.Setenv("PATH", newPathEnv)
-	return pathEnv
 }

--- a/pkg/reporting/reporting_test.go
+++ b/pkg/reporting/reporting_test.go
@@ -17,7 +17,6 @@
 package reporting_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -27,15 +26,15 @@ import (
 )
 
 func TestReportingWithDefaults(t *testing.T) {
-	createCredentialsConfig(t)
-	defer os.RemoveAll(".chef") // clean up
-	createConfigToml(t)
-	defer os.RemoveAll(".chef-workstation") // clean up
+	defer os.RemoveAll(createCredentialsConfig(t))
+	defer os.RemoveAll(createConfigToml(t))
 
 	cfg, err := subject.NewDefault()
 	if assert.Nil(t, err) {
 		assert.Equal(t, "foo", cfg.ClientName)
-		assert.Equal(t, ".chef/foo.pem", cfg.ClientKey)
+		// the key should contain .chef/foo.pem
+		assert.Contains(t, cfg.ClientKey, "foo.pem")
+		assert.Contains(t, cfg.ClientKey, ".chef")
 		assert.Equal(t, "chef-server.example.com/organizations/bubu", cfg.ChefServerUrl)
 		assert.Equal(t, false, cfg.NoSSLVerify)
 		assert.Equal(t, true, cfg.Telemetry.Enable, "telemetry.enable is not well parsed")
@@ -48,8 +47,7 @@ func TestReportingWithDefaults(t *testing.T) {
 }
 
 func TestReportingWirhOverrides(t *testing.T) {
-	createCredentialsConfig(t)
-	defer os.RemoveAll(".chef") // clean up
+	defer os.RemoveAll(createCredentialsConfig(t))
 
 	cfg, err := subject.NewDefault(
 		func(c *subject.Reporting) {
@@ -58,7 +56,9 @@ func TestReportingWirhOverrides(t *testing.T) {
 	)
 	if assert.Nil(t, err) {
 		assert.Equal(t, "foo", cfg.ClientName)
-		assert.Equal(t, ".chef/foo.pem", cfg.ClientKey)
+		// the key should contain .chef/foo.pem
+		assert.Contains(t, cfg.ClientKey, "foo.pem")
+		assert.Contains(t, cfg.ClientKey, ".chef")
 		assert.Equal(t, "chef-server.example.com/organizations/bubu", cfg.ChefServerUrl)
 		assert.Equal(t, true, cfg.NoSSLVerify)
 	}
@@ -66,9 +66,6 @@ func TestReportingWirhOverrides(t *testing.T) {
 
 // NOTE: @afiune we don't report an error if we were unable to load the config.toml
 func TestReportingNewDefaultErrorWithoutCredentials(t *testing.T) {
-	// NOTE - this fails if you have a local credential set configured.
-	//        here (and elsewhere) we should prevent filesystem access in
-	//        unit tests. This looks promising: https://github.com/spf13/afero
 	cfg, err := subject.NewDefault()
 
 	if assert.NotNil(t, err) {
@@ -77,143 +74,5 @@ func TestReportingNewDefaultErrorWithoutCredentials(t *testing.T) {
 		assert.Contains(t, err.Error(), "setup your local credentials config by following this documentation")
 		assert.Contains(t, err.Error(), "https://docs.chef.io/knife_setup.html#knife-profiles")
 		assert.Equal(t, subject.Reporting{}, cfg)
-	}
-}
-
-// when calling this function, make sure to add the defer clean up as the below example
-// ```go
-// createCredentialsConfig(t)
-// defer os.RemoveAll(".chef") // clean up
-// ```
-func createCredentialsConfig(t *testing.T) {
-	if err := os.MkdirAll(".chef", os.ModePerm); err != nil {
-		t.Fatal(err)
-	}
-
-	creds := []byte(`[default]
-client_name = "foo"
-client_key = ".chef/foo.pem"
-chef_server_url = "chef-server.example.com/organizations/bubu"
-
-[dev]
-client_name = "dev"
-client_key = ".chef/dev.pem"
-chef_server_url = "chef-server.example.com/organizations/dev"
-
-[empty]
-client_name = "empty"
-client_key = ".chef/empty.pem"
-chef_server_url = "chef-server.example.com/organizations/empty"
-`)
-	err := ioutil.WriteFile(".chef/credentials", creds, 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = ioutil.WriteFile(".chef/foo.pem", key(), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = ioutil.WriteFile(".chef/dev.pem", key(), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = ioutil.WriteFile(".chef/empty.pem", []byte(""), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-// mocked key
-func key() []byte {
-	return []byte(`-----BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEAuip6wlbkvuHvFl4m3Fzpqk3eSCBOudfubLdVZb8bWa0UM++d
-fipPJadjDkrf1tlvKhjjoUF1XTizhI1xholJTRm92AjNi+rLWuCcn3Zih58xHTrl
-S6+V8VHzmUB9iEDc7iyCdkXabDmoKhvu6CgagrFMN2maBjX7toaTOsAeGahVz3bv
-inO/V61ea1an2TCgJ/Ovp77728kmPYQgQAceewelxgx/FwsroPVS0XFlBaRme8bg
-Lc2VFJWeID27905ecPXQOZCfm5H2aCfpmzNIwHZ9WRpvOnpQxOXYYsimRGiAhwYA
-zkC/FoCgny6ohMjhisibfHI6g7N+Y/iaWBImBwIDAQABAoIBAQCCS+sBi+mrw9wf
-zqPqRclxXfC+kIYpQn1ob+SAQwJ0gFQMiZ+0Rw6ALyiAP11tNV+9mg/vtC3doirb
-Elgrrni0UtjxlC+wxxOvNlfIsAYEICIy8B6+G1WZwh752w5BSAyZUmO5PejDKJOP
-bV+H81GiuU671dhskmnrdUMksoQeteU0Xc1Uc8tYEAp7u/5KEA7WUCF5KiDvp5VC
-5YSHC+slrIi0D+2xyWrPMFNqASN05Ke4yXhFEl9tuwiXUFSWahVlyY+mbsfE7xCX
-GKPXjXpRFDIg/3EOdL0Cy1U6UUAFkYvYfU08UpQpxNA+ffgUcXbUfbLNcaCHfRl0
-L/cPXEmhAoGBAO1/Q6M3sfNtyTMSaRoYxX+k8eV4A2qGy8B1rWv/oNV8NLAdbRBL
-9E8QPk4TLSnTf9tK34JqGpUXHktYRvjFasB43V+LGhmrcflQ1YEeGodm3iiBZAuE
-7KUX6x71/n3pHiOBea32hDBrGd2MLsX31Nwzo3e152JxLwZifpl48VsxAoGBAMir
-cijumQLLIyB1urn1lQqtJm/Cd8jXypwkv6m0qD3bl5/shOEUTqnuGOnXJk2AcfNG
-uv2TmP07gjz8JGTqInYgVHZrPd5Cu16TUl6TVezLu0Mu0yjpqlaSar4gTx1UT5ic
-annHVa784VQnS/85WzVgldqvPSNsGhlDyfwkf9a3AoGBAJiUQmgByBmUVsaw9UUG
-1RuEZMP/rnIp14z2DUxtFm8RNOhQf1kQ8ww4a07Nkx5j+qhwGdg3Qoy2JYhSVoZM
-jqDJBa/0Nfh35Ok/vWsOZAzJUcDEH/omk8Ic87kYYT+THQHClOHmllZk+GEVRpd4
-+Q/fPQ4Tl2vvOz7m2F7RDH6BAoGAS3oA5FhqANz7B1iAtTUjq/JYhKy2dTqFIJnJ
-5UDoDuwraaGCkU4cEFpX0Ix2AayQL5qo9nuvjX/2io2j+rj94URjwG6xxImBBB+R
-WbU9GmW+t5RDJB5PTWSg9YYde8Ccd6BNhCRvm/PNpONq+EJQhhEgDDLhYhNk9Z/D
-tyzbUJ0CgYB9XAHT44ZbMVF6mF9egdx8HMQg0KgjUL8mAi5gvlbZjLyxpS0nnLhz
-mjnO50tNmJ5OE3QGOEMr9Tzs6Sj7g7pv1McWtCpuvgAg8R4qL0a7MJ8qGSK29RP8
-rfCdVg0GCAEjF9Dx+rdn4rWwP/8yJ5I61pWUDgmhKXyki94nPZt6Zg==
------END RSA PRIVATE KEY-----`)
-}
-
-// when calling this function, make sure to add the defer clean up as the below example
-// ```go
-// createConfigToml(t)
-// defer os.RemoveAll(".chef-workstation") // clean up
-// ```
-func createConfigToml(t *testing.T) {
-	if err := os.MkdirAll(".chef-workstation", os.ModePerm); err != nil {
-		t.Fatal(err)
-	}
-
-	creds := []byte(`
-[telemetry]
-enable = true
-dev = false
-
-[log]
-level="debug"
-location="/path/to/chef-workstation.log"
-
-[cache]
-path="/path/to/.cache/chef-workstation"
-
-[connection]
-default_protocol="ssh"
-default_user="bubu"
-
-[connection.ssh]
-ssl=true
-ssl_verify=true
-
-[connection.winrm]
-ssl=false
-ssl_verify=false
-
-[chef]
-trusted_certs_dir="/path/to/mytrustedcerts"
-cookbook_repo_paths = [
-  "/path/to/cookbooks",
-  "/var/chef/cookbooks"
-]
-
-[updates]
-enable = true
-channel = "current"
-interval_minutes = 60
-
-[data_collector]
-url="https://1.1.1.1/data-collector/v0/"
-token="ABCDEF0123456789"
-
-[features]
-foo = true
-bar = true
-xyz = false
-
-[dev]
-spinner = true
-`)
-	err := ioutil.WriteFile(".chef-workstation/config.toml", creds, 0666)
-	if err != nil {
-		t.Fatal(err)
 	}
 }

--- a/pkg/reporting/setup_test.go
+++ b/pkg/reporting/setup_test.go
@@ -1,0 +1,263 @@
+//
+// Copyright 2019 Chef Software, Inc.
+// Author: Salim Afiune <afiune@chef.io>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package reporting_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// store previous home directory
+	oldHome := os.Getenv("HOME")
+
+	// create a temporal directory and use it as a mocked home directory
+	tmpHome, err := ioutil.TempDir("", "mock-home")
+	if err != nil {
+		panic("unable to create a temporal directory")
+	}
+	os.Setenv("HOME", tmpHome)
+
+	// run each test
+	exitCode := m.Run()
+
+	// setup the previous home directory
+	os.Setenv("HOME", oldHome)
+
+	// remove the temporal home directory
+	os.RemoveAll(tmpHome)
+
+	os.Exit(exitCode)
+}
+
+// when calling this function, make sure to wrap it inside a defer statement
+// ```go
+// defer os.RemoveAll(createCredentialsConfig(t))
+// ```
+func createCredentialsConfig(t *testing.T) string {
+
+	// for security to NOT delete a real .chef/ directory on our home directories
+	// lets verify if the directory exist, if so, panic and inform the developer
+	var (
+		home     = os.Getenv("HOME")
+		homeChef = filepath.Join(home, ".chef")
+	)
+	if _, err := os.Stat(homeChef); err == nil {
+		// Oh oh, exists!
+		panic(`
+
+!!! ATTENTION !!!
+
+You might be using the func createCredentialsConfig() without mocking the
+HOME directory inside the Go tests. Please, verify that the test package
+has a TestMain() func that mocks the HOME directory. (look at setup_test.go)
+
+    `)
+	}
+
+	if err := os.MkdirAll(homeChef, os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		credsPath    = filepath.Join(homeChef, "credentials")
+		fooPemPath   = filepath.Join(homeChef, "foo.pem")
+		devPemPath   = filepath.Join(homeChef, "dev.pem")
+		emptyPemPath = filepath.Join(homeChef, "empty.pem")
+		creds        = []byte(`[default]
+client_name = "foo"
+client_key = "` + fooPemPath + `"
+chef_server_url = "chef-server.example.com/organizations/bubu"
+
+[dev]
+client_name = "dev"
+client_key = "` + devPemPath + `"
+chef_server_url = "chef-server.example.com/organizations/dev"
+
+[empty]
+client_name = "empty"
+client_key = "` + emptyPemPath + `"
+chef_server_url = "chef-server.example.com/organizations/empty"
+`)
+	)
+	err := ioutil.WriteFile(credsPath, creds, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ioutil.WriteFile(fooPemPath, key(), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ioutil.WriteFile(devPemPath, key(), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ioutil.WriteFile(emptyPemPath, []byte(""), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return homeChef
+}
+
+// mocked key
+func key() []byte {
+	return []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAuip6wlbkvuHvFl4m3Fzpqk3eSCBOudfubLdVZb8bWa0UM++d
+fipPJadjDkrf1tlvKhjjoUF1XTizhI1xholJTRm92AjNi+rLWuCcn3Zih58xHTrl
+S6+V8VHzmUB9iEDc7iyCdkXabDmoKhvu6CgagrFMN2maBjX7toaTOsAeGahVz3bv
+inO/V61ea1an2TCgJ/Ovp77728kmPYQgQAceewelxgx/FwsroPVS0XFlBaRme8bg
+Lc2VFJWeID27905ecPXQOZCfm5H2aCfpmzNIwHZ9WRpvOnpQxOXYYsimRGiAhwYA
+zkC/FoCgny6ohMjhisibfHI6g7N+Y/iaWBImBwIDAQABAoIBAQCCS+sBi+mrw9wf
+zqPqRclxXfC+kIYpQn1ob+SAQwJ0gFQMiZ+0Rw6ALyiAP11tNV+9mg/vtC3doirb
+Elgrrni0UtjxlC+wxxOvNlfIsAYEICIy8B6+G1WZwh752w5BSAyZUmO5PejDKJOP
+bV+H81GiuU671dhskmnrdUMksoQeteU0Xc1Uc8tYEAp7u/5KEA7WUCF5KiDvp5VC
+5YSHC+slrIi0D+2xyWrPMFNqASN05Ke4yXhFEl9tuwiXUFSWahVlyY+mbsfE7xCX
+GKPXjXpRFDIg/3EOdL0Cy1U6UUAFkYvYfU08UpQpxNA+ffgUcXbUfbLNcaCHfRl0
+L/cPXEmhAoGBAO1/Q6M3sfNtyTMSaRoYxX+k8eV4A2qGy8B1rWv/oNV8NLAdbRBL
+9E8QPk4TLSnTf9tK34JqGpUXHktYRvjFasB43V+LGhmrcflQ1YEeGodm3iiBZAuE
+7KUX6x71/n3pHiOBea32hDBrGd2MLsX31Nwzo3e152JxLwZifpl48VsxAoGBAMir
+cijumQLLIyB1urn1lQqtJm/Cd8jXypwkv6m0qD3bl5/shOEUTqnuGOnXJk2AcfNG
+uv2TmP07gjz8JGTqInYgVHZrPd5Cu16TUl6TVezLu0Mu0yjpqlaSar4gTx1UT5ic
+annHVa784VQnS/85WzVgldqvPSNsGhlDyfwkf9a3AoGBAJiUQmgByBmUVsaw9UUG
+1RuEZMP/rnIp14z2DUxtFm8RNOhQf1kQ8ww4a07Nkx5j+qhwGdg3Qoy2JYhSVoZM
+jqDJBa/0Nfh35Ok/vWsOZAzJUcDEH/omk8Ic87kYYT+THQHClOHmllZk+GEVRpd4
++Q/fPQ4Tl2vvOz7m2F7RDH6BAoGAS3oA5FhqANz7B1iAtTUjq/JYhKy2dTqFIJnJ
+5UDoDuwraaGCkU4cEFpX0Ix2AayQL5qo9nuvjX/2io2j+rj94URjwG6xxImBBB+R
+WbU9GmW+t5RDJB5PTWSg9YYde8Ccd6BNhCRvm/PNpONq+EJQhhEgDDLhYhNk9Z/D
+tyzbUJ0CgYB9XAHT44ZbMVF6mF9egdx8HMQg0KgjUL8mAi5gvlbZjLyxpS0nnLhz
+mjnO50tNmJ5OE3QGOEMr9Tzs6Sj7g7pv1McWtCpuvgAg8R4qL0a7MJ8qGSK29RP8
+rfCdVg0GCAEjF9Dx+rdn4rWwP/8yJ5I61pWUDgmhKXyki94nPZt6Zg==
+-----END RSA PRIVATE KEY-----`)
+}
+
+// when calling this function, make sure to wrap it inside a defer statement
+// ```go
+// defer os.RemoveAll(createConfigToml(t))
+// ```
+func createConfigToml(t *testing.T) string {
+
+	// for security to NOT delete a real .chef-workstation/ directory on our
+	// home directories lets verify if the directory exist, if so, panic and
+	// inform the developer
+	var (
+		home         = os.Getenv("HOME")
+		homeWS       = filepath.Join(home, ".chef-workstation")
+		wsConfigToml = filepath.Join(homeWS, "config.toml")
+	)
+	if _, err := os.Stat(homeWS); err == nil {
+		// Oh oh, exists!
+		panic(`
+
+!!! ATTENTION !!!
+
+You might be using the func createConfigToml() without mocking the
+HOME directory inside the Go tests. Please, verify that the test package
+has a TestMain() func that mocks the HOME directory. (look at setup_test.go)
+
+    `)
+	}
+
+	if err := os.MkdirAll(homeWS, os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	creds := []byte(`
+[telemetry]
+enable = true
+dev = false
+
+[log]
+level="debug"
+location="/path/to/chef-workstation.log"
+
+[cache]
+path="/path/to/.cache/chef-workstation"
+
+[connection]
+default_protocol="ssh"
+default_user="bubu"
+
+[connection.ssh]
+ssl=true
+ssl_verify=true
+
+[connection.winrm]
+ssl=false
+ssl_verify=false
+
+[chef]
+trusted_certs_dir="/path/to/mytrustedcerts"
+cookbook_repo_paths = [
+  "/path/to/cookbooks",
+  "/var/chef/cookbooks"
+]
+
+[updates]
+enable = true
+channel = "current"
+interval_minutes = 60
+
+[data_collector]
+url="https://1.1.1.1/data-collector/v0/"
+token="ABCDEF0123456789"
+
+[features]
+foo = true
+bar = true
+xyz = false
+
+[dev]
+spinner = true
+`)
+	err := ioutil.WriteFile(wsConfigToml, creds, 0666)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return homeWS
+}
+
+// setups up the binstubs directory at the front of the PATH environment
+// environment and returns the previous value so that callers can set
+// it back to its original value
+//
+// example:
+//
+// ```go
+// savedPath := setupBinstubsDir()
+// defer os.Setenv("PATH", savedPath)
+// ```
+func setupBinstubsDir() string {
+	pathEnv := os.Getenv("PATH")
+	newPathEnv := binstubsDir() + ":" + pathEnv
+	os.Setenv("PATH", newPathEnv)
+	return pathEnv
+}
+
+// returns the binstubs/ directory path
+func binstubsDir() string {
+	pwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	return filepath.Join(pwd, "..", "..", "binstubs")
+}

--- a/pkg/reporting/setup_test.go
+++ b/pkg/reporting/setup_test.go
@@ -28,10 +28,10 @@ func TestMain(m *testing.M) {
 	// store previous home directory
 	oldHome := os.Getenv("HOME")
 
-	// create a temporal directory and use it as a mocked home directory
+	// create a temporary directory and use it as a mocked home directory
 	tmpHome, err := ioutil.TempDir("", "mock-home")
 	if err != nil {
-		panic("unable to create a temporal directory")
+		panic("unable to create a temporary directory")
 	}
 	os.Setenv("HOME", tmpHome)
 
@@ -41,7 +41,7 @@ func TestMain(m *testing.M) {
 	// setup the previous home directory
 	os.Setenv("HOME", oldHome)
 
-	// remove the temporal home directory
+	// remove the temporary home directory
 	os.RemoveAll(tmpHome)
 
 	os.Exit(exitCode)


### PR DESCRIPTION
## Description

Mocking the Home directory will allow us to play safe with the `.chef`
and `.chef-workstation` directories.

![tenor-2099693](https://user-images.githubusercontent.com/5712253/71189454-25e44b00-2283-11ea-9050-ff0e6f2f2066.gif)

Signed-off-by: Salim Afiune <afiune@chef.io>

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Closes https://github.com/chef/chef-analyze/issues/57

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
