### PR TITLE
cookstyle:(config) use --force-default-config

### DIFF
--- a/pkg/reporting/cookstyle.go
+++ b/pkg/reporting/cookstyle.go
@@ -94,7 +94,10 @@ func (ecr *CookstyleRunner) Run(workingDir string) (*CookstyleResult, error) {
 
 func NewCookstyleRunner() *CookstyleRunner {
 	return &CookstyleRunner{
-		Opts: []string{"--format", "json", "--only", "ChefDeprecations,ChefCorrectness"},
+		Opts: []string{
+			"--format", "json",
+			"--only", "ChefDeprecations,ChefCorrectness",
+			"--force-default-config"},
 	}
 }
 

--- a/pkg/reporting/cookstyle_test.go
+++ b/pkg/reporting/cookstyle_test.go
@@ -65,8 +65,10 @@ func TestCookstyleRunnerWithBinstubs(t *testing.T) {
 
 	runner := subject.NewCookstyleRunner()
 	assert.Equal(t,
-		[]string{"--format", "json",
-			"--only", "ChefDeprecations,ChefCorrectness"},
+		[]string{
+			"--format", "json",
+			"--only", "ChefDeprecations,ChefCorrectness",
+			"--force-default-config"},
 		runner.Opts,
 		"default cookstyle options need to be updated",
 	)


### PR DESCRIPTION
## Description

Doing a little bit of research on cookstyle/rubocop I found an option
that will help use ignore any `.rubocop.yml` that might conflict with
the current state of things.

This is a possible solution instead of deleting the file we will ignore
it so that we do not modify the customers data just yet. We might do
that in next iteration to fix things on cookbooks/data.

Signed-off-by: Salim Afiune <afiune@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
