### PR TITLE
Move remaining IO out of reporting pkg

### DIFF
--- a/cmd/report.go
+++ b/cmd/report.go
@@ -102,7 +102,7 @@ provided when the report is generated.
 			}
 
 			if cookbooksState.TotalCookbooks == 0 {
-				fmt.Printf(" No cookbooks available for analysis\n")
+				fmt.Printf(" (0 found)\n\nNo cookbooks available for analysis.\n")
 				return nil
 			}
 			fmt.Printf(" (%d found)\n", cookbooksState.TotalCookbooks)


### PR DESCRIPTION
This draft PR does the following: 
- moves all IO (uincluding progress) out of the reporting package.  This now reports progress through analyzes back to the caller via a channel. 
- fixes cases where we don't always report 100% progress on completion - no more paths to exit the pipeline that don't report 
- speeds up run time on large data sets by about 10% by eliminating channel bottlenecks/conflicts


Fixes: #136 
