### PR TITLE
Implements sorting on cookbooks report #98

### DIFF
--- a/pkg/formatter/csv.go
+++ b/pkg/formatter/csv.go
@@ -53,6 +53,8 @@ func MakeCookbooksReportCSV(state *reporting.CookbooksReport) *FormattedResult {
 	}
 	csvWriter.Write(tableHeaders)
 
+	sortCookbookRecords(state.Records)
+
 	for _, record := range state.Records {
 		nodesString := "None"
 		if record.NumNodesAffected() != 0 {

--- a/pkg/formatter/csv_test.go
+++ b/pkg/formatter/csv_test.go
@@ -171,8 +171,8 @@ func TestMakeCookbooksReportCSV_ErrorReport(t *testing.T) {
 	lines := strings.Split(actual.Errors, "\n")
 	assert.Equal(t, 4, len(lines))
 	assert.Equal(t, lines[0], " - my-cookbook (1.0): could not download")
-	assert.Equal(t, lines[1], " - their-cookbook (1.1): could not look up usage")
-	assert.Equal(t, lines[2], " - our-cookbook (1.2): cookstyle error")
+	assert.Equal(t, lines[1], " - our-cookbook (1.2): cookstyle error")
+	assert.Equal(t, lines[2], " - their-cookbook (1.1): could not look up usage")
 	assert.Equal(t, lines[3], "")
 }
 

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -17,6 +17,12 @@
 
 package formatter
 
+import (
+	"sort"
+
+	"github.com/chef/chef-analyze/pkg/reporting"
+)
+
 // FormattedResult contains the report and its errors
 type FormattedResult struct {
 	Report string
@@ -41,4 +47,13 @@ func stringOrPlaceholder(s, placeholder string) string {
 		return placeholder
 	}
 	return s
+}
+
+func sortCookbookRecords(records []*reporting.CookbookRecord) {
+	sort.Sort(reporting.CookbookRecordsByNameVersion(records))
+
+	// Also sort the node names.
+	for _, record := range records {
+		sort.Strings(record.Nodes)
+	}
 }

--- a/pkg/formatter/formatter_internal_test.go
+++ b/pkg/formatter/formatter_internal_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/chef/chef-analyze/pkg/reporting"
 )
 
 func TestStringOrEmptyPlaceholder(t *testing.T) {
@@ -36,4 +38,95 @@ func TestStringOrUnknownPlaceholder(t *testing.T) {
 func TestStringOrPlaceholder(t *testing.T) {
 	assert.Equal(t, "placeholder", stringOrPlaceholder("", "placeholder"))
 	assert.Equal(t, "foo", stringOrPlaceholder("foo", "placeholder"))
+}
+
+func TestSortCookbookRecords(t *testing.T) {
+	records := []*reporting.CookbookRecord{
+		&reporting.CookbookRecord{
+			Name:    "foo",
+			Version: "1.0.0",
+		},
+		&reporting.CookbookRecord{
+			Name:    "baz",
+			Version: "1.0.0",
+		},
+		&reporting.CookbookRecord{
+			Name:    "zaz",
+			Version: "1.0.0",
+		},
+		&reporting.CookbookRecord{
+			Name:    "foo",
+			Version: "2.0.0",
+		},
+		&reporting.CookbookRecord{
+			Name:    "bar",
+			Version: "1.0.0",
+		},
+		&reporting.CookbookRecord{
+			Name:    "foo",
+			Version: "1.1.0",
+		},
+		&reporting.CookbookRecord{
+			Name:    "raz",
+			Version: "1.0.0",
+		},
+		&reporting.CookbookRecord{
+			Name:    "foo",
+			Version: "1.0.1",
+		},
+	}
+	expected := []*reporting.CookbookRecord{
+		&reporting.CookbookRecord{
+			Name:    "bar",
+			Version: "1.0.0",
+		},
+		&reporting.CookbookRecord{
+			Name:    "baz",
+			Version: "1.0.0",
+		},
+		&reporting.CookbookRecord{
+			Name:    "foo",
+			Version: "1.0.0",
+		},
+		&reporting.CookbookRecord{
+			Name:    "foo",
+			Version: "1.0.1",
+		},
+		&reporting.CookbookRecord{
+			Name:    "foo",
+			Version: "1.1.0",
+		},
+		&reporting.CookbookRecord{
+			Name:    "foo",
+			Version: "2.0.0",
+		},
+		&reporting.CookbookRecord{
+			Name:    "raz",
+			Version: "1.0.0",
+		},
+		&reporting.CookbookRecord{
+			Name:    "zaz",
+			Version: "1.0.0",
+		},
+	}
+	sortCookbookRecords(records)
+	assert.Equal(t, expected, records)
+}
+
+func TestSortCookbookRecordsSortsNodes(t *testing.T) {
+	records := []*reporting.CookbookRecord{
+		&reporting.CookbookRecord{
+			Name: "foo",
+			Nodes: []string{
+				"node2",
+				"node1",
+			},
+		},
+	}
+	expected := []string{
+		"node1",
+		"node2",
+	}
+	sortCookbookRecords(records)
+	assert.Equal(t, expected, records[0].Nodes)
 }

--- a/pkg/formatter/table.go
+++ b/pkg/formatter/table.go
@@ -81,6 +81,8 @@ func CookbooksReportSummary(state *reporting.CookbooksReport) FormattedResult {
 	// unwrappable content will expand beyond this limit.
 	table.SetColWidth(MinTermWidth / len(CookbooksReportHeader))
 
+	sortCookbookRecords(state.Records)
+
 	for _, record := range state.Records {
 		row := []string{record.Name, record.Version}
 

--- a/pkg/formatter/txt.go
+++ b/pkg/formatter/txt.go
@@ -42,6 +42,8 @@ func MakeCookbooksReportTXT(state *reporting.CookbooksReport) *FormattedResult {
 		return &FormattedResult{strBuilder.String(), ""}
 	}
 
+	sortCookbookRecords(state.Records)
+
 	for _, record := range state.Records {
 		strBuilder.WriteString(fmt.Sprintf("> Cookbook: %v (%v)\n", record.Name, record.Version))
 

--- a/pkg/formatter/txt_test.go
+++ b/pkg/formatter/txt_test.go
@@ -98,8 +98,8 @@ func TestMakeCookbooksReportTXT_ErrorReport(t *testing.T) {
 	lines := strings.Split(actual.Errors, "\n")
 	assert.Equal(t, 4, len(lines))
 	assert.Equal(t, lines[0], " - my-cookbook (1.0): could not download")
-	assert.Equal(t, lines[1], " - their-cookbook (1.1): could not look up usage")
-	assert.Equal(t, lines[2], " - our-cookbook (1.2): cookstyle error")
+	assert.Equal(t, lines[1], " - our-cookbook (1.2): cookstyle error")
+	assert.Equal(t, lines[2], " - their-cookbook (1.1): could not look up usage")
 	assert.Equal(t, lines[3], "")
 }
 

--- a/pkg/reporting/cookbooks.go
+++ b/pkg/reporting/cookbooks.go
@@ -76,12 +76,6 @@ func (cr CookbookRecord) Errors() []error {
 	return errs
 }
 
-// internally used to submit items to the workers
-type cookbookItem struct {
-	Name    string
-	Version string
-}
-
 // NumNodesAffected shortcut
 func (cr *CookbookRecord) NumNodesAffected() int {
 	return len(cr.Nodes)
@@ -107,6 +101,28 @@ func (cr *CookbookRecord) NumCorrectable() int {
 		}
 	}
 	return i
+}
+
+// Sort interface the sorts cookbook records by name.
+type CookbookRecordsByNameVersion []*CookbookRecord
+
+func (crs CookbookRecordsByNameVersion) Len() int {
+	return len(crs)
+}
+func (crs CookbookRecordsByNameVersion) Swap(i, j int) {
+	crs[i], crs[j] = crs[j], crs[i]
+}
+func (crs CookbookRecordsByNameVersion) Less(i, j int) bool {
+	if crs[i].Name != crs[j].Name {
+		return crs[i].Name < crs[j].Name
+	}
+	return crs[i].Version < crs[j].Version
+}
+
+// internally used to submit items to the workers
+type cookbookItem struct {
+	Name    string
+	Version string
 }
 
 func NewCookbooksReport(

--- a/pkg/reporting/cookbooks_test.go
+++ b/pkg/reporting/cookbooks_test.go
@@ -571,3 +571,44 @@ func TestCookbooks_withHeavyLoad(t *testing.T) {
 		}
 	}
 }
+
+func TestCookbookRecordsByNameVersion_Len(t *testing.T) {
+	crs := []*subject.CookbookRecord{
+		&subject.CookbookRecord{Name: "cookbook_name"},
+	}
+	assert.Equal(t, 1, subject.CookbookRecordsByNameVersion.Len(crs))
+}
+
+func TestCookbookRecordsByNameVersion_Swap(t *testing.T) {
+	crs := []*subject.CookbookRecord{
+		&subject.CookbookRecord{Name: "cb1"},
+		&subject.CookbookRecord{Name: "cb2"},
+	}
+	expected := []*subject.CookbookRecord{
+		&subject.CookbookRecord{Name: "cb2"},
+		&subject.CookbookRecord{Name: "cb1"},
+	}
+	subject.CookbookRecordsByNameVersion.Swap(crs, 0, 1)
+	assert.Equal(t, expected, crs)
+}
+
+func TestCookbookRecordsByNameVersion_Less(t *testing.T) {
+	crs := []*subject.CookbookRecord{
+		&subject.CookbookRecord{Name: "cb1", Version: "1.0.1"},
+		&subject.CookbookRecord{Name: "cb2", Version: "1.0.1"},
+		&subject.CookbookRecord{Name: "cb2", Version: "1.0.0"},
+		&subject.CookbookRecord{Name: "cb1", Version: "1.0.0"},
+	}
+	assert.True(t, subject.CookbookRecordsByNameVersion.Less(crs, 0, 1))
+	assert.True(t, subject.CookbookRecordsByNameVersion.Less(crs, 0, 2))
+	assert.False(t, subject.CookbookRecordsByNameVersion.Less(crs, 0, 3))
+	assert.False(t, subject.CookbookRecordsByNameVersion.Less(crs, 1, 0))
+	assert.False(t, subject.CookbookRecordsByNameVersion.Less(crs, 1, 2))
+	assert.False(t, subject.CookbookRecordsByNameVersion.Less(crs, 1, 3))
+	assert.False(t, subject.CookbookRecordsByNameVersion.Less(crs, 2, 0))
+	assert.True(t, subject.CookbookRecordsByNameVersion.Less(crs, 2, 1))
+	assert.False(t, subject.CookbookRecordsByNameVersion.Less(crs, 2, 3))
+	assert.True(t, subject.CookbookRecordsByNameVersion.Less(crs, 3, 0))
+	assert.True(t, subject.CookbookRecordsByNameVersion.Less(crs, 3, 1))
+	assert.True(t, subject.CookbookRecordsByNameVersion.Less(crs, 3, 2))
+}


### PR DESCRIPTION
## Description
* Sorts cookbooks by name, then version in all reports.
* Sorts nodes by name in csv and tx reports

Added new sorting function in formater that is called by each report. My thinking is we can expand the interface to this funciton if we ever wan't configurable sorting. Also adds a sorting interface 'CookbookRecordsByName' in reporting/cookbooks.go for CookbookRecords keeping that logic encasulated with the type.

Signed-off-by: Jon Morrow <jmorrow@chef.io>

## Related Issue
Fixes #98

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
