### PR TITLE
Add ability to anonymize cookbook and node names

### DIFF
--- a/cmd/report.go
+++ b/cmd/report.go
@@ -95,6 +95,7 @@ provided when the report is generated.
 				cookbooksFlags.runCookstyle,
 				cookbooksFlags.onlyUnused,
 				cookbooksFlags.workers,
+				reportsFlags.anonymize,
 			)
 
 			if err != nil {
@@ -174,7 +175,7 @@ provided when the report is generated.
 			}
 
 			fmt.Println("Analyzing nodes...")
-			report, err := reporting.GenerateNodesReport(chefClient.Search)
+			report, err := reporting.GenerateNodesReport(chefClient.Search, reportsFlags.anonymize)
 			if err != nil {
 				return err
 			}
@@ -221,6 +222,7 @@ provided when the report is generated.
 		profile       string
 		noSSLverify   bool
 		format        string
+		anonymize     bool
 	}
 )
 
@@ -263,6 +265,11 @@ func init() {
 		"Disable SSL certificate verification",
 	)
 
+	reportCmd.PersistentFlags().BoolVarP(
+		&reportsFlags.anonymize,
+		"anonymize", "a", false,
+		"replace cookbook and node names with hash values",
+	)
 	// cookbooks cmd flags
 	reportCookbooksCmd.PersistentFlags().IntVarP(
 		&cookbooksFlags.workers,
@@ -279,6 +286,7 @@ func init() {
 		"verify-upgrade", "V", false,
 		"verify the upgrade compatibility of every cookbook",
 	)
+
 	// adds the cookbooks command as a sub-command of the report command
 	// => chef-analyze report cookbooks
 	reportCmd.AddCommand(reportCookbooksCmd)

--- a/pkg/reporting/reporting.go
+++ b/pkg/reporting/reporting.go
@@ -17,6 +17,9 @@
 package reporting
 
 import (
+	"crypto/sha256"
+	"fmt"
+
 	"github.com/chef/go-libs/config"
 	"github.com/chef/go-libs/credentials"
 )
@@ -56,4 +59,22 @@ func NewDefault(overrides ...OverrideFunc) (Reporting, error) {
 	}
 
 	return rCfg, nil
+}
+
+// This returns the value referenced by `key` in `values`. If value is nil,
+// it returns an empty string; otherwise it returns the original string.
+func safeStringFromMap(values map[string]interface{}, key string) string {
+	if values[key] == nil {
+		return ""
+	}
+	return values[key].(string)
+}
+
+// Converts a string to its sha256 hash value.
+// Keeps blank strings blank.
+func hashString(name string) string {
+	if name == "" {
+		return name
+	}
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(name)))
 }


### PR DESCRIPTION
Some customers will not wish to share their internal naming scheme,
because of concerns that data may leak.  The new flag `--anonymize`
accommodates them by obscuring cookbook and node names - it
converts them to their to sha-256  checksums in base64.

Currently, cookbook name located in a file path (such as in the errors
report) will still be shown, but all other cases are replaced.

Cookstyle errors will report file name, but they do not include the full
path - only the relative path to cookbook directory root; which means
that cookbook name will not be shown at all in cookstyle output.

Pending: tests

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
