### PR TITLE
Adds "chef analyze capture NODE"

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -47,9 +47,7 @@ var (
 		Long: `Captures a node's state as a local chef-repo, which
 can then be used to converge locally.`,
 		RunE: func(_ *cobra.Command, args []string) error {
-			// TODO - support multiple node names?
 			creds, err := credentials.FromViper(
-				// TODO this isn't just reportsflags any longer.
 				reportsFlags.profile,
 				overrideCredentials(),
 			)
@@ -81,9 +79,7 @@ can then be used to converge locally.`,
 			_, err = os.Stat(dirName)
 			if err == nil {
 				fmt.Printf(RepositoryAlreadyExistsE002, dirName, nodeName)
-
 				return nil
-
 			} else {
 				if !os.IsNotExist(err) {
 					return err

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -1,0 +1,117 @@
+//
+// Copyright 2020 Chef Software, Inc.
+// Author: Marc Paradise <marc@chef.io>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/chef/chef-analyze/pkg/reporting"
+	"github.com/chef/go-libs/credentials"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// behavior:
+	//  - repo dir: if it does not exist, we will create it by invoking chef generate repo node-NAME-repo.
+	//  - capture json object definitions for node, env, roles. Save them to the chef-repo.
+	//  - capture cookbooks and versions from automatic attributes. Save each cookbook @ version to the chef-repo.
+	// Possible options (future)
+	// --repo-dir -> root dir of repo to use.  Will update existing if one exists.
+	// Thoughts: this may make it harder to coordinate, now user will have to track telling kitchen about
+	//           repo location? Or is that something we'd capture in the kitchen.yml we generate eventually?
+	//           to t
+	//     Default: ./node-NAME-repo
+
+	captureCmd = &cobra.Command{
+		Use:   "capture NODE-NAME",
+		Short: "Capture a node's state into a local chef-repo",
+		Args:  cobra.ExactArgs(1),
+		Long: `Captures a node's state as a local chef-repo, which
+can then be used to converge locally.`,
+		RunE: func(_ *cobra.Command, args []string) error {
+			// TODO - support multiple node names?
+			creds, err := credentials.FromViper(
+				// TODO this isn't just reportsflags any longer.
+				reportsFlags.profile,
+				overrideCredentials(),
+			)
+			if err != nil {
+				return err
+			}
+
+			nodeName := args[0]
+			err = createOutputDirectories()
+			if err != nil {
+				return err
+			}
+
+			// TODO - puting this in reporting for now, because
+			// of common bits already in that package.  Longer-term
+			// we'll want to move the common bits to their own package
+			// (credentials handling, common object structures like chef client)
+			cfg := &reporting.Reporting{Credentials: creds}
+			if reportsFlags.noSSLverify {
+				cfg.NoSSLVerify = true
+			}
+
+			chefClient, err := reporting.NewChefClient(cfg)
+			if err != nil {
+				return err
+			}
+
+			repoName := fmt.Sprintf("node-%s-repo", nodeName)
+			// TODO - configurable?
+			dirName := fmt.Sprintf("./%s", repoName)
+			// TODO - abort if it exists, have them remove it first.
+
+			fmt.Println(" - Setting up local repository")
+			cmd := exec.Command("chef", "generate", "repo", repoName)
+			_, err = cmd.Output()
+			if err != nil {
+				return err
+			}
+
+			nc := reporting.NewNodeCapture(nodeName, dirName,
+				chefClient.Nodes, chefClient.Roles,
+				chefClient.Environments, chefClient.Cookbooks,
+			)
+			go nc.Run()
+			for progress := range nc.Progress {
+				switch progress {
+				case reporting.FetchingNode:
+					fmt.Printf(" - Capturing node '%s'\n", nodeName)
+				case reporting.FetchingCookbooks:
+					fmt.Println(" - Capturing cookbooks...")
+				case reporting.FetchingRoles:
+					fmt.Println(" - Capturing roles...")
+				case reporting.FetchingEnvironment:
+					fmt.Println(" - Capturing environment...")
+				case reporting.FetchingComplete:
+				}
+			}
+			if nc.Error != nil {
+				return nc.Error
+			}
+
+			// TODO - be smart enough to nkow if we should say 'created' or 'updated'
+			fmt.Printf("Repository has been created in '%s'\n", dirName)
+			return nil
+		},
+	}
+)

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -111,7 +111,7 @@ can then be used to converge locally.`,
 			nc := reporting.NewNodeCapture(nodeName, dirName,
 				chefClient.Nodes, chefClient.Roles,
 				chefClient.Environments, chefClient.Cookbooks,
-				reporting.ObjectWriter{RootDir: dirName},
+				&reporting.ObjectWriter{RootDir: dirName},
 			)
 			go nc.Run()
 			for progress := range nc.Progress {

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -84,10 +84,16 @@ can then be used to converge locally.`,
 			// abort if it exists, have them remove it first.
 			_, err = os.Stat(dirName)
 			if err == nil {
-				fmt.Printf("\nThe repository already exists in %s.\n\n", dirName)
-				// In future versions we should permit specifying a --repo-save-path  as an alternative
-				// to deletion.
-				fmt.Printf("To re-run capture for node %s, delete this directory\n\n", nodeName)
+				fmt.Printf(RepositoryAlreadyExistsE002, dirName, nodeName)
+
+				// TODO we'll need finer-grained control over errors/output.  For example
+				// in order to exit non-zero we have to return an error. But if we return an error,
+				// gt
+				// TODO all of our error returns (including this one) cause usage a message to be displayed.
+				// If we can't control when that happens, we should disable it since it's ofte
+				// not the right behavior - most error scenarios aren't usage-related.
+				return nil
+
 			} else {
 				if !os.IsNotExist(err) {
 					return err
@@ -134,7 +140,6 @@ can then be used to converge locally.`,
 				return nc.Error
 			}
 
-			// TODO - be smart enough to nkow if we should say 'created' or 'updated'
 			fmt.Printf("Repository has been created in '%s'\n", dirName)
 			return nil
 		},

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -104,11 +104,12 @@ can then be used to converge locally.`,
 				return errors.Wrap(err, "Could not remove pre-created repo content: example cookbook")
 			}
 
-			nc := reporting.NewNodeCapture(nodeName, dirName,
+			capturer := reporting.NewNodeCapturer(
 				chefClient.Nodes, chefClient.Roles,
 				chefClient.Environments, chefClient.Cookbooks,
 				&reporting.ObjectWriter{RootDir: dirName},
 			)
+			nc := reporting.NewNodeCapture(nodeName, dirName, capturer)
 			go nc.Run()
 			for progress := range nc.Progress {
 				switch progress {

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -63,10 +63,6 @@ can then be used to converge locally.`,
 				return err
 			}
 
-			// TODO - puting this in reporting for now, because
-			// of common bits already in that package.  Longer-term
-			// we'll want to move the common bits to their own package
-			// (credentials handling, common object structures like chef client)
 			cfg := &reporting.Reporting{Credentials: creds}
 			if reportsFlags.noSSLverify {
 				cfg.NoSSLVerify = true
@@ -86,12 +82,6 @@ can then be used to converge locally.`,
 			if err == nil {
 				fmt.Printf(RepositoryAlreadyExistsE002, dirName, nodeName)
 
-				// TODO we'll need finer-grained control over errors/output.  For example
-				// in order to exit non-zero we have to return an error. But if we return an error,
-				// gt
-				// TODO all of our error returns (including this one) cause usage a message to be displayed.
-				// If we can't control when that happens, we should disable it since it's ofte
-				// not the right behavior - most error scenarios aren't usage-related.
 				return nil
 
 			} else {
@@ -121,6 +111,7 @@ can then be used to converge locally.`,
 			nc := reporting.NewNodeCapture(nodeName, dirName,
 				chefClient.Nodes, chefClient.Roles,
 				chefClient.Environments, chefClient.Cookbooks,
+				reporting.ObjectWriter{RootDir: dirName},
 			)
 			go nc.Run()
 			for progress := range nc.Progress {

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -25,6 +25,8 @@ package cmd
 const (
 	// MissingMinimumParametersErr user feedback
 	MissingMinimumParametersErr = `
+  E001
+
   there are missing parameters for this tool to work, provide a credentials file:
     --credentials string
 
@@ -32,5 +34,15 @@ const (
     --client_key string
     --client_name string
     --chef_server_url string
+
+`
+
+	RepositoryAlreadyExistsE002 = `
+  E002
+
+  The repository already exists in %s.
+
+  To re-run capture for node %s, delete this directory.
+
 `
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,7 +33,7 @@ var (
 		Use:   dist.Exec,
 		Short: fmt.Sprintf("A CLI to analyze artifacts from a %s", dist.ServerProduct),
 		Long: fmt.Sprintf(`Analyze your %s artifacts to understand the effort to upgrade
-your infrastructure by generating eports, automatically fixing violations
+your infrastructure by generating reports, automatically fixing violations
 and/or deprecations, and generating Effortless packages.
 `, dist.ServerProduct),
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,7 +33,7 @@ var (
 		Use:   dist.Exec,
 		Short: fmt.Sprintf("A CLI to analyze artifacts from a %s", dist.ServerProduct),
 		Long: fmt.Sprintf(`Analyze your %s artifacts to understand the effort to upgrade
-your infrastructure by generating reports, automatically fixing violations
+your infrastructure by generating eports, automatically fixing violations
 and/or deprecations, and generating Effortless packages.
 `, dist.ServerProduct),
 	}
@@ -64,6 +64,8 @@ func init() {
 	rootCmd.AddCommand(uploadCmd)
 	// adds the session command from 'cmd/session.go'
 	rootCmd.AddCommand(sessionCmd)
+	// adds the capture command from 'cmd/capture.go'
+	rootCmd.AddCommand(captureCmd)
 }
 
 func initConfig() {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/chef/chef-analyze
 go 1.13
 
 require (
-	github.com/aws/aws-sdk-go v1.29.31
+	github.com/aws/aws-sdk-go v1.29.32
 	github.com/chef/go-chef v0.4.0
 	github.com/chef/go-libs v0.2.0
 	github.com/cheggaaa/pb/v3 v3.0.4

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/aws/aws-sdk-go v1.29.30 h1:HEEb7p5H850+hKVLRif2fWpaoJe5ZkZ5WUJwJ+CKWV
 github.com/aws/aws-sdk-go v1.29.30/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
 github.com/aws/aws-sdk-go v1.29.31 h1:y4lIvJf88grxomd/caxacLrNFIz2U3jld9vHElK/FhA=
 github.com/aws/aws-sdk-go v1.29.31/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
+github.com/aws/aws-sdk-go v1.29.32 h1:o4I8Qc+h9ht8NXvTHeXZH3EmtSUZ/PC0bg9Wawr+aTA=
+github.com/aws/aws-sdk-go v1.29.32/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=

--- a/pkg/reporting/capture.go
+++ b/pkg/reporting/capture.go
@@ -11,17 +11,18 @@ import (
 )
 
 type NodeCapture struct {
+	Progress      chan int
+	Error         error
 	name          string
 	repositoryDir string
 	nodes         NodesInterface
 	roles         RolesInterface
 	env           EnvironmentInterface
 	cookbooks     CookbookInterface
-	Progress      chan int
-	Error         error
-	// Maybe workers
 }
 
+// Events that we publish on the Progress channel when
+// performing a node capture
 const (
 	FetchingNode = iota
 	FetchingEnvironment
@@ -30,94 +31,118 @@ const (
 	FetchingComplete
 )
 
-type CapturedNode struct {
-	Name      string
-	Cookbooks map[string]interface{}
-
-	Node  chef.Node
-	Env   *chef.Environment
-	Roles []*chef.Role
-}
-
-// Initialize a NodeCapture
+// Initialize a NodeCapture. Creates a Progress channel that callers can monitor for updates
 func NewNodeCapture(nodeName string, repositoryDir string, nodes NodesInterface,
 	roles RolesInterface, env EnvironmentInterface, cookbooks CookbookInterface) *NodeCapture {
 	return &NodeCapture{name: nodeName, nodes: nodes, roles: roles,
 		env: env, cookbooks: cookbooks, repositoryDir: repositoryDir,
-		Progress: make(chan int)}
+		// 5 possible events in a Run - let's not block our activity in case the caller
+		// doesn't pick them up
+		Progress: make(chan int, 5)}
 }
 
 func (nc *NodeCapture) Run() {
-	defer func() {
-		nc.Progress <- FetchingComplete
-		close(nc.Progress)
-	}()
+	defer func() { close(nc.Progress) }()
 
 	nc.Progress <- FetchingNode
+	node, err := nc.captureNodeObject()
+	if err != nil {
+		nc.Error = errors.Wrapf(err, "unable to capture node '%s'", nc.name)
+		return
+	}
+
+	nc.Progress <- FetchingCookbooks
+	err = nc.captureCookbookObjects(node.AutomaticAttributes["cookbooks"].(map[string]interface{}))
+	if err != nil {
+		nc.Error = errors.Wrapf(err, "unable to capture node cookbooks for '%s'", nc.name)
+		return
+	}
+
+	nc.Progress <- FetchingEnvironment
+	err = nc.captureEnvObject(node)
+	if err != nil {
+		nc.Error = errors.Wrapf(err, "unable to capture enviroment")
+		return
+	}
+
+	nc.Progress <- FetchingRoles
+	err = nc.captureRoleObjects(node)
+	err = nc.captureEnvObject(node)
+	if err != nil {
+		nc.Error = errors.Wrapf(err, "unable to capture role(s)")
+		return
+	}
+
+	nc.Progress <- FetchingComplete
+}
+func (nc *NodeCapture) captureNodeObject() (*chef.Node, error) {
 	node, err := nc.nodes.Get(nc.name)
 	if err != nil {
-		nc.Error = errors.Wrapf(err, "unable to retrieve node: %s", nc.name)
-		return
+		return nil, errors.Wrapf(err, "unable to retrieve node: %s", nc.name)
 	}
 	err = saveObjectAsJSON(nc.repositoryDir, "nodes", node.Name, node)
 	if err != nil {
-		nc.Error = errors.Wrap(err, "failed to save node. This is a bug, please report it.")
-		return
+		return nil, errors.Wrap(err, "failed to save node. This is a bug, please report it.")
 	}
 
 	// In this pass we are not supporting policyfiles. For now, that
 	// means we'll raise an errro when the node has policyfile enabled,
 	// to avoid the risk of reporting back inaccurate results based on non-PF assumptions.
 	if node.PolicyName != "" || node.PolicyGroup != "" {
-		nc.Error = errors.New(fmt.Sprintf("Node %s is managed by Policyfile. Unsupported at this time.", nc.name))
-		return
+		return nil, errors.New(fmt.Sprintf("Node %s is managed by Policyfile. Unsupported at this time.", nc.name))
 	}
-	// Cookbooks from Node object
-	cookbooks := node.AutomaticAttributes["cookbooks"].(map[string]interface{})
+	return &node, nil
+}
 
-	nc.Progress <- FetchingCookbooks
+func (nc *NodeCapture) captureCookbookObjects(cookbooks map[string]interface{}) error {
+	// Cookbooks from Node object
+	cookbookDir := fmt.Sprintf("%s/cookbooks", nc.repositoryDir)
 	for name, version_data := range cookbooks {
 		version := safeStringFromMap(version_data.(map[string]interface{}), "version")
 		// TODO - this will come back with version-named cookbook dirs. we'll want to make that optional
 		// in the underlying interface, and/or clean up after the fact.
-		err = nc.cookbooks.DownloadTo(name, version, fmt.Sprintf("%s/cookbooks", nc.repositoryDir))
+		err := nc.cookbooks.DownloadTo(name, version, cookbookDir)
 		if err != nil {
-			nc.Error = errors.Wrapf(err, "Failed to download cookbook %s v%s", name, version)
-			return
+			return errors.Wrapf(err, "Failed to download cookbook %s v%s", name, version)
+		}
+		// The cookbook directory will have been created as 'name-version'.  We need it to be just 'name'
+		// so that it can be picked up by chef-zero when requested from within kitchen.
+
+		err = os.Rename(fmt.Sprintf("%s/%s-%s", cookbookDir, name, version), fmt.Sprintf("%s/%s", cookbookDir, name))
+		if err != nil {
+			return errors.Wrapf(err, "failed to rename cookbook %s-%s to non-versioned name", name, version)
 		}
 	}
+	return nil
+}
 
-	// Environment
-	nc.Progress <- FetchingEnvironment
+func (nc *NodeCapture) captureEnvObject(node *chef.Node) error {
 	env, err := nc.env.Get(node.Environment)
 	if err != nil {
-		nc.Error = errors.Wrapf(err, "unable to retrieve node environment: %s", node.Environment)
-		return
+		return errors.Wrapf(err, "unable to retrieve node environment: %s", node.Environment)
 	}
 
 	err = saveObjectAsJSON(nc.repositoryDir, "environments", node.Environment, env)
 	if err != nil {
-		nc.Error = errors.Wrap(err, "failed to save environment. This is a bug, please report it.")
-		return
+		return errors.Wrap(err, "failed to save environment. This is a bug, please report it.")
 	}
+	return nil
+}
 
-	// Roles
-	nc.Progress <- FetchingRoles
+func (nc *NodeCapture) captureRoleObjects(node *chef.Node) error {
+
 	roleNames := filterRoles(node.RunList)
 	for _, roleName := range roleNames {
 		role, err := nc.roles.Get(roleName)
 		if err != nil {
-			nc.Error = errors.Wrapf(err, "unable to retrieve role: %s", roleName)
-			return
+			return errors.Wrapf(err, "unable to retrieve role: %s", roleName)
 		}
 		err = saveObjectAsJSON(nc.repositoryDir, "roles", roleName, role)
 		if err != nil {
-			nc.Error = errors.Wrapf(err, "failed to save role %s. This is a bug, please report it:", roleName)
-			return
+			return errors.Wrapf(err, "failed to save role %s. This is a bug, please report it:", roleName)
 		}
 	}
-
-	// return &CapturedNode{Name: node.Name, Node: node, Cookbooks: cookbooks, Env: env, Roles: roles}, nil
+	return nil
 }
 
 func saveObjectAsJSON(rootDir string, subDir string, objName string, obj interface{}) error {

--- a/pkg/reporting/capture.go
+++ b/pkg/reporting/capture.go
@@ -30,16 +30,27 @@ import (
 	"github.com/pkg/errors"
 )
 
+type NodeCaptureInterface interface {
+	CaptureCookbooks(string, map[string]interface{}) error
+	CaptureNodeObject(node string) (*chef.Node, error)
+	CaptureEnvObject(string) error
+	CaptureRoleObjects([]string) error
+}
+
 type NodeCapture struct {
+	name          string
+	capturer      NodeCaptureInterface
+	repositoryDir string
 	Progress      chan int
 	Error         error
-	name          string
-	repositoryDir string
-	nodes         NodesInterface
-	roles         RolesInterface
-	env           EnvironmentInterface
-	cookbooks     CookbookInterface
-	writer        ObjectWriterInterface
+}
+
+type NodeCapturer struct {
+	nodes     NodesInterface
+	roles     RolesInterface
+	env       EnvironmentInterface
+	cookbooks CookbookInterface
+	writer    ObjectWriterInterface
 }
 
 // Events that we publish on the Progress channel when
@@ -52,43 +63,48 @@ const (
 	FetchingComplete
 )
 
-// Initialize a NodeCapture. Creates a Progress channel that callers can monitor for updates
-func NewNodeCapture(nodeName string, repositoryDir string, nodes NodesInterface,
-	roles RolesInterface, env EnvironmentInterface, cookbooks CookbookInterface, writer ObjectWriterInterface) *NodeCapture {
-	return &NodeCapture{name: nodeName, nodes: nodes, roles: roles,
-		env: env, cookbooks: cookbooks, repositoryDir: repositoryDir,
-		writer: writer,
+func NewNodeCapture(name string, repositoryDir string, capturer NodeCaptureInterface) *NodeCapture {
+	return &NodeCapture{
+		name:          name,
+		capturer:      capturer,
+		repositoryDir: repositoryDir,
 		// 5 possible events in a Run - let's not block our activity in case the caller
 		// doesn't pick them up
-		Progress: make(chan int, 5)}
+		Progress: make(chan int, 5),
+	}
 }
 
+// Initialize a NodeCapture. Creates a Progress channel that callers can monitor for updates
 func (nc *NodeCapture) Run() {
 	defer func() { close(nc.Progress) }()
 
 	nc.Progress <- FetchingNode
-	node, err := nc.CaptureNodeObject()
+	node, err := nc.capturer.CaptureNodeObject(nc.name)
 	if err != nil {
 		nc.Error = errors.Wrapf(err, "unable to capture node '%s'", nc.name)
 		return
 	}
 
 	nc.Progress <- FetchingCookbooks
-	err = nc.CaptureCookbooks(node.AutomaticAttributes["cookbooks"].(map[string]interface{}))
-	if err != nil {
-		nc.Error = errors.Wrapf(err, "unable to capture node cookbooks for '%s'", nc.name)
-		return
+	// If a node has never converged, it will not have this attribute:
+	cookbooks := node.AutomaticAttributes["cookbooks"]
+	if cookbooks != nil {
+		err = nc.capturer.CaptureCookbooks(nc.repositoryDir, cookbooks.(map[string]interface{}))
+		if err != nil {
+			nc.Error = errors.Wrapf(err, "unable to capture node cookbooks for '%s'", nc.name)
+			return
+		}
 	}
 
 	nc.Progress <- FetchingEnvironment
-	err = nc.CaptureEnvObject(node.Environment)
+	err = nc.capturer.CaptureEnvObject(node.Environment)
 	if err != nil {
 		nc.Error = errors.Wrapf(err, "unable to capture environment")
 		return
 	}
 
 	nc.Progress <- FetchingRoles
-	err = nc.CaptureRoleObjects(node.RunList)
+	err = nc.capturer.CaptureRoleObjects(node.RunList)
 	if err != nil {
 		nc.Error = errors.Wrapf(err, "unable to capture role(s)")
 		return
@@ -97,19 +113,32 @@ func (nc *NodeCapture) Run() {
 	nc.Progress <- FetchingComplete
 }
 
+func NewNodeCapturer(
+	nodes NodesInterface,
+	roles RolesInterface, env EnvironmentInterface,
+	cookbooks CookbookInterface, writer ObjectWriterInterface) *NodeCapturer {
+	return &NodeCapturer{
+		nodes:     nodes,
+		roles:     roles,
+		env:       env,
+		cookbooks: cookbooks,
+		writer:    writer}
+
+}
+
 // Capture the the node nc.Name from Chef Server to
 // repositoryDir/nodes/NAME.json
 // Returns the chef.Node object.
-func (nc *NodeCapture) CaptureNodeObject() (*chef.Node, error) {
-	node, err := nc.nodes.Get(nc.name)
+func (nc *NodeCapturer) CaptureNodeObject(name string) (*chef.Node, error) {
+	node, err := nc.nodes.Get(name)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to retrieve node '%s'", nc.name)
+		return nil, errors.Wrapf(err, "unable to retrieve node '%s'", name)
 	}
 	// In this pass we are not supporting policyfiles. For now, that
 	// means we'll raise an error when the node has policyfile enabled,
 	// to avoid the risk of reporting back inaccurate results based on non-PF assumptions.
 	if node.PolicyName != "" || node.PolicyGroup != "" {
-		return nil, errors.New(fmt.Sprintf("Node %s is managed by Policyfile. Unsupported at this time.", nc.name))
+		return nil, errors.New(fmt.Sprintf("Node %s is managed by Policyfile. Unsupported at this time.", name))
 	}
 	err = nc.writer.WriteNode(&node)
 	if err != nil {
@@ -121,8 +150,8 @@ func (nc *NodeCapture) CaptureNodeObject() (*chef.Node, error) {
 
 // Given a map of cookbook [ name ] : { "version" : version }, download the cookbooks
 // from Chef Server into repositoryDir/cookbooks
-func (nc *NodeCapture) CaptureCookbooks(cookbooks map[string]interface{}) error {
-	cookbookDir := fmt.Sprintf("%s/cookbooks", nc.repositoryDir)
+func (nc *NodeCapturer) CaptureCookbooks(repositoryDir string, cookbooks map[string]interface{}) error {
+	cookbookDir := fmt.Sprintf("%s/cookbooks", repositoryDir)
 	for name, version_data := range cookbooks {
 		version := safeStringFromMap(version_data.(map[string]interface{}), "version")
 		err := nc.cookbooks.DownloadTo(name, version, cookbookDir)
@@ -140,7 +169,7 @@ func (nc *NodeCapture) CaptureCookbooks(cookbooks map[string]interface{}) error 
 	return nil
 }
 
-func (nc *NodeCapture) CaptureEnvObject(environment string) error {
+func (nc *NodeCapturer) CaptureEnvObject(environment string) error {
 	env, err := nc.env.Get(environment)
 	if err != nil {
 		return errors.Wrapf(err, "unable to retrieve node environment: %s", environment)
@@ -153,7 +182,7 @@ func (nc *NodeCapture) CaptureEnvObject(environment string) error {
 	return nil
 }
 
-func (nc *NodeCapture) CaptureRoleObjects(runList []string) error {
+func (nc *NodeCapturer) CaptureRoleObjects(runList []string) error {
 	roleNames := filterRoles(runList)
 	for _, roleName := range roleNames {
 		role, err := nc.roles.Get(roleName)

--- a/pkg/reporting/capture.go
+++ b/pkg/reporting/capture.go
@@ -1,8 +1,28 @@
+//
+// Copyright 2020 Chef Software, Inc.
+// Author: Marc Paradise <marc@chef.io>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// TODO - puting this in reporting for now, because
+// of common bits already in that package.  Longer-term
+// we'll want to move the common bits to their own package
+// (credentials handling, common object structures like chef client)
 package reporting
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -19,6 +39,7 @@ type NodeCapture struct {
 	roles         RolesInterface
 	env           EnvironmentInterface
 	cookbooks     CookbookInterface
+	writer        ObjectWriter
 }
 
 // Events that we publish on the Progress channel when
@@ -33,9 +54,10 @@ const (
 
 // Initialize a NodeCapture. Creates a Progress channel that callers can monitor for updates
 func NewNodeCapture(nodeName string, repositoryDir string, nodes NodesInterface,
-	roles RolesInterface, env EnvironmentInterface, cookbooks CookbookInterface) *NodeCapture {
+	roles RolesInterface, env EnvironmentInterface, cookbooks CookbookInterface, writer ObjectWriter) *NodeCapture {
 	return &NodeCapture{name: nodeName, nodes: nodes, roles: roles,
 		env: env, cookbooks: cookbooks, repositoryDir: repositoryDir,
+		writer: writer,
 		// 5 possible events in a Run - let's not block our activity in case the caller
 		// doesn't pick them up
 		Progress: make(chan int, 5)}
@@ -59,15 +81,14 @@ func (nc *NodeCapture) Run() {
 	}
 
 	nc.Progress <- FetchingEnvironment
-	err = nc.captureEnvObject(node)
+	err = nc.captureEnvObject(node.Environment)
 	if err != nil {
-		nc.Error = errors.Wrapf(err, "unable to capture enviroment")
+		nc.Error = errors.Wrapf(err, "unable to capture environment")
 		return
 	}
 
 	nc.Progress <- FetchingRoles
-	err = nc.captureRoleObjects(node)
-	err = nc.captureEnvObject(node)
+	err = nc.captureRoleObjects(node.RunList)
 	if err != nil {
 		nc.Error = errors.Wrapf(err, "unable to capture role(s)")
 		return
@@ -75,18 +96,22 @@ func (nc *NodeCapture) Run() {
 
 	nc.Progress <- FetchingComplete
 }
+
+// Capture the the node nc.Name from Chef Server to
+// repositoryDir/nodes/NAME.json
+// Returns the chef.Node object.
 func (nc *NodeCapture) captureNodeObject() (*chef.Node, error) {
 	node, err := nc.nodes.Get(nc.name)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to retrieve node: %s", nc.name)
+		return nil, errors.Wrapf(err, "unable  retrieve node: %s", nc.name)
 	}
-	err = saveObjectAsJSON(nc.repositoryDir, "nodes", node.Name, node)
+	err = nc.writer.WriteNode(&node)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to save node. This is a bug, please report it.")
 	}
 
 	// In this pass we are not supporting policyfiles. For now, that
-	// means we'll raise an errro when the node has policyfile enabled,
+	// means we'll raise an error when the node has policyfile enabled,
 	// to avoid the risk of reporting back inaccurate results based on non-PF assumptions.
 	if node.PolicyName != "" || node.PolicyGroup != "" {
 		return nil, errors.New(fmt.Sprintf("Node %s is managed by Policyfile. Unsupported at this time.", nc.name))
@@ -94,20 +119,19 @@ func (nc *NodeCapture) captureNodeObject() (*chef.Node, error) {
 	return &node, nil
 }
 
+// Given a map of cookbook [ name ] : { "version" : version }, download the cookbooks
+// from Chef Server into repositoryDir/cookbooks
 func (nc *NodeCapture) captureCookbookObjects(cookbooks map[string]interface{}) error {
-	// Cookbooks from Node object
 	cookbookDir := fmt.Sprintf("%s/cookbooks", nc.repositoryDir)
 	for name, version_data := range cookbooks {
 		version := safeStringFromMap(version_data.(map[string]interface{}), "version")
-		// TODO - this will come back with version-named cookbook dirs. we'll want to make that optional
-		// in the underlying interface, and/or clean up after the fact.
 		err := nc.cookbooks.DownloadTo(name, version, cookbookDir)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to download cookbook %s v%s", name, version)
 		}
+
 		// The cookbook directory will have been created as 'name-version'.  We need it to be just 'name'
 		// so that it can be picked up by chef-zero when requested from within kitchen.
-
 		err = os.Rename(fmt.Sprintf("%s/%s-%s", cookbookDir, name, version), fmt.Sprintf("%s/%s", cookbookDir, name))
 		if err != nil {
 			return errors.Wrapf(err, "failed to rename cookbook %s-%s to non-versioned name", name, version)
@@ -116,28 +140,28 @@ func (nc *NodeCapture) captureCookbookObjects(cookbooks map[string]interface{}) 
 	return nil
 }
 
-func (nc *NodeCapture) captureEnvObject(node *chef.Node) error {
-	env, err := nc.env.Get(node.Environment)
+func (nc *NodeCapture) captureEnvObject(environment string) error {
+	env, err := nc.env.Get(environment)
 	if err != nil {
-		return errors.Wrapf(err, "unable to retrieve node environment: %s", node.Environment)
+		return errors.Wrapf(err, "unable to retrieve node environment: %s", environment)
 	}
 
-	err = saveObjectAsJSON(nc.repositoryDir, "environments", node.Environment, env)
+	err = nc.writer.WriteEnvironment(env)
 	if err != nil {
 		return errors.Wrap(err, "failed to save environment. This is a bug, please report it.")
 	}
 	return nil
 }
 
-func (nc *NodeCapture) captureRoleObjects(node *chef.Node) error {
+func (nc *NodeCapture) captureRoleObjects(runList []string) error {
 
-	roleNames := filterRoles(node.RunList)
+	roleNames := filterRoles(runList)
 	for _, roleName := range roleNames {
 		role, err := nc.roles.Get(roleName)
 		if err != nil {
 			return errors.Wrapf(err, "unable to retrieve role: %s", roleName)
 		}
-		err = saveObjectAsJSON(nc.repositoryDir, "roles", roleName, role)
+		err = nc.writer.WriteRole(role)
 		if err != nil {
 			return errors.Wrapf(err, "failed to save role %s. This is a bug, please report it:", roleName)
 		}
@@ -145,32 +169,9 @@ func (nc *NodeCapture) captureRoleObjects(node *chef.Node) error {
 	return nil
 }
 
-func saveObjectAsJSON(rootDir string, subDir string, objName string, obj interface{}) error {
-	var err error
-	dirName := fmt.Sprintf("%s/%s", rootDir, subDir)
-	path := fmt.Sprintf("%s/%s/%s.json", rootDir, subDir, objName)
-	if _, err := os.Stat(dirName); os.IsNotExist(err) {
-		err = os.MkdirAll(dirName, 0700)
-	}
-	if err != nil {
-		return errors.Wrapf(err, "Failed to create directory %s", dirName)
-	}
-	body, err := chef.JSONReader(obj)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to convert %s to json. If you see this, it's a bug.  Please report it.", objName)
-	}
-
-	content, err := ioutil.ReadAll(body)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to read %s %s", subDir, objName)
-	}
-
-	err = ioutil.WriteFile(path, content, 0600)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to save file %s", path)
-	}
-	return nil
-}
+// filters a run list, return an array of roles
+// as identified by a run list item being in the form "role[...]"
+// Will return zero-size array if no roles are in the run list.
 func filterRoles(possibleRoles []string) []string {
 	roles := make([]string, 0)
 	for _, role := range possibleRoles {
@@ -187,5 +188,3 @@ func filterRoles(possibleRoles []string) []string {
 
 	return roles
 }
-
-// Node: comes from ndoe endpoint in chef server.

--- a/pkg/reporting/capture.go
+++ b/pkg/reporting/capture.go
@@ -1,0 +1,166 @@
+package reporting
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	chef "github.com/chef/go-chef"
+	"github.com/pkg/errors"
+)
+
+type NodeCapture struct {
+	name          string
+	repositoryDir string
+	nodes         NodesInterface
+	roles         RolesInterface
+	env           EnvironmentInterface
+	cookbooks     CookbookInterface
+	Progress      chan int
+	Error         error
+	// Maybe workers
+}
+
+const (
+	FetchingNode = iota
+	FetchingEnvironment
+	FetchingRoles
+	FetchingCookbooks
+	FetchingComplete
+)
+
+type CapturedNode struct {
+	Name      string
+	Cookbooks map[string]interface{}
+
+	Node  chef.Node
+	Env   *chef.Environment
+	Roles []*chef.Role
+}
+
+// Initialize a NodeCapture
+func NewNodeCapture(nodeName string, repositoryDir string, nodes NodesInterface,
+	roles RolesInterface, env EnvironmentInterface, cookbooks CookbookInterface) *NodeCapture {
+	return &NodeCapture{name: nodeName, nodes: nodes, roles: roles,
+		env: env, cookbooks: cookbooks, repositoryDir: repositoryDir,
+		Progress: make(chan int)}
+}
+
+func (nc *NodeCapture) Run() {
+	defer func() {
+		nc.Progress <- FetchingComplete
+		close(nc.Progress)
+	}()
+
+	nc.Progress <- FetchingNode
+	node, err := nc.nodes.Get(nc.name)
+	if err != nil {
+		nc.Error = errors.Wrapf(err, "unable to retrieve node: %s", nc.name)
+		return
+	}
+	err = saveObjectAsJSON(nc.repositoryDir, "nodes", node.Name, node)
+	if err != nil {
+		nc.Error = errors.Wrap(err, "failed to save node. This is a bug, please report it.")
+		return
+	}
+
+	// In this pass we are not supporting policyfiles. For now, that
+	// means we'll raise an errro when the node has policyfile enabled,
+	// to avoid the risk of reporting back inaccurate results based on non-PF assumptions.
+	if node.PolicyName != "" || node.PolicyGroup != "" {
+		nc.Error = errors.New(fmt.Sprintf("Node %s is managed by Policyfile. Unsupported at this time.", nc.name))
+		return
+	}
+	// Cookbooks from Node object
+	cookbooks := node.AutomaticAttributes["cookbooks"].(map[string]interface{})
+
+	nc.Progress <- FetchingCookbooks
+	for name, version_data := range cookbooks {
+		version := safeStringFromMap(version_data.(map[string]interface{}), "version")
+		// TODO - this will come back with version-named cookbook dirs. we'll want to make that optional
+		// in the underlying interface, and/or clean up after the fact.
+		err = nc.cookbooks.DownloadTo(name, version, fmt.Sprintf("%s/cookbooks", nc.repositoryDir))
+		if err != nil {
+			nc.Error = errors.Wrapf(err, "Failed to download cookbook %s v%s", name, version)
+			return
+		}
+	}
+
+	// Environment
+	nc.Progress <- FetchingEnvironment
+	env, err := nc.env.Get(node.Environment)
+	if err != nil {
+		nc.Error = errors.Wrapf(err, "unable to retrieve node environment: %s", node.Environment)
+		return
+	}
+
+	err = saveObjectAsJSON(nc.repositoryDir, "environments", node.Environment, env)
+	if err != nil {
+		nc.Error = errors.Wrap(err, "failed to save environment. This is a bug, please report it.")
+		return
+	}
+
+	// Roles
+	nc.Progress <- FetchingRoles
+	roleNames := filterRoles(node.RunList)
+	for _, roleName := range roleNames {
+		role, err := nc.roles.Get(roleName)
+		if err != nil {
+			nc.Error = errors.Wrapf(err, "unable to retrieve role: %s", roleName)
+			return
+		}
+		err = saveObjectAsJSON(nc.repositoryDir, "roles", roleName, role)
+		if err != nil {
+			nc.Error = errors.Wrapf(err, "failed to save role %s. This is a bug, please report it:", roleName)
+			return
+		}
+	}
+
+	// return &CapturedNode{Name: node.Name, Node: node, Cookbooks: cookbooks, Env: env, Roles: roles}, nil
+}
+
+func saveObjectAsJSON(rootDir string, subDir string, objName string, obj interface{}) error {
+	var err error
+	dirName := fmt.Sprintf("%s/%s", rootDir, subDir)
+	path := fmt.Sprintf("%s/%s/%s.json", rootDir, subDir, objName)
+	if _, err := os.Stat(dirName); os.IsNotExist(err) {
+		err = os.MkdirAll(dirName, 0700)
+	}
+	if err != nil {
+		return errors.Wrapf(err, "Failed to create directory %s", dirName)
+	}
+	body, err := chef.JSONReader(obj)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to convert %s to json. If you see this, it's a bug.  Please report it.", objName)
+	}
+
+	content, err := ioutil.ReadAll(body)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to read %s %s", subDir, objName)
+	}
+
+	err = ioutil.WriteFile(path, content, 0600)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to save file %s", path)
+	}
+	return nil
+}
+func filterRoles(possibleRoles []string) []string {
+	roles := make([]string, 0)
+	for _, role := range possibleRoles {
+		pos := strings.Index(role, "role[")
+		if pos == -1 {
+			continue
+		}
+		// can't remember if chef server allows unicode in run lists,
+		// so we'll play it safe and convert to runes.
+		runes := []rune(role)
+		stop := len(role) - 1
+		roles = append(roles, string(runes[5:stop]))
+	}
+
+	return roles
+}
+
+// Node: comes from ndoe endpoint in chef server.

--- a/pkg/reporting/capture_test.go
+++ b/pkg/reporting/capture_test.go
@@ -1,0 +1,325 @@
+// Copyright 2020 Chef Software, Inc.
+// Author: Marc Paradise <marc@chef.io>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package reporting_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	subject "github.com/chef/chef-analyze/pkg/reporting"
+	chef "github.com/chef/go-chef"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCaptureNodeObject(t *testing.T) {
+	expectedNode := chef.Node{
+		Name:        "node1",
+		Environment: "_default",
+		RunList:     []string{"cookbook1::recipe1", "role:mockrole"},
+		PolicyName:  "",
+		PolicyGroup: "",
+	}
+	writer := ObjectWriterMock{}
+	nc := subject.NewNodeCapture("",
+		"",
+		NodeMock{Error: nil, Node: expectedNode},
+		RoleMock{},
+		EnvMock{},
+		CookbookMock{},
+		&writer,
+	)
+	actualNode, err := nc.CaptureNodeObject()
+	assert.Equal(t, &expectedNode, actualNode)
+	assert.Equal(t, nil, err)
+}
+
+func TestCaptureNodeObjectWithPolicyError(t *testing.T) {
+	expectedNode := chef.Node{
+		Name:        "node1",
+		Environment: "_default",
+		RunList:     []string{"cookbook1::recipe1", "role:mockrole"},
+		PolicyName:  "",
+		PolicyGroup: "mypolicygroup",
+	}
+	writer := ObjectWriterMock{}
+	nc := subject.NewNodeCapture("",
+		"",
+		NodeMock{Error: nil, Node: expectedNode},
+		RoleMock{},
+		EnvMock{},
+		CookbookMock{},
+		&writer,
+	)
+	actualNode, err := nc.CaptureNodeObject()
+	assert.Nil(t, actualNode)
+	if assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "managed by Policyfile")
+	}
+}
+
+func TestCaptureNodeObjectWithErrorOnFetch(t *testing.T) {
+	underlyingErr := errors.New("fetch error")
+	writer := ObjectWriterMock{}
+	nc := subject.NewNodeCapture("node1", "",
+		NodeMock{Error: underlyingErr},
+		RoleMock{},
+		EnvMock{},
+		CookbookMock{},
+		&writer,
+	)
+	_, err := nc.CaptureNodeObject()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "fetch error") // because it's wrapped
+}
+func TestCaptureNodeObjectWithErrorOnSave(t *testing.T) {
+	node := chef.Node{}
+	writer := ObjectWriterMock{Error: errors.New("failed to write")}
+	nc := subject.NewNodeCapture("", "",
+		NodeMock{Node: node},
+		RoleMock{},
+		EnvMock{},
+		CookbookMock{},
+		&writer,
+	)
+	_, err := nc.CaptureNodeObject()
+	if assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "failed to write")
+	}
+}
+
+func TestCaptureRoleObjects(t *testing.T) {
+	expectedRole := chef.Role{
+		Name: "role1",
+	}
+	writer := ObjectWriterMock{}
+	nc := subject.NewNodeCapture("", "",
+		NodeMock{},
+		RoleMock{Role: &expectedRole},
+		EnvMock{},
+		CookbookMock{},
+		&writer,
+	)
+	err := nc.CaptureRoleObjects([]string{"role[role1]"})
+	assert.Equal(t, &expectedRole, writer.ReceivedObject)
+	assert.Nil(t, err)
+}
+
+func TestCaptureRoleObjectsWithErrorOnFetch(t *testing.T) {
+	writer := ObjectWriterMock{}
+	nc := subject.NewNodeCapture("",
+		"",
+		NodeMock{},
+		RoleMock{Error: errors.New("failed to fetch")},
+		EnvMock{},
+		CookbookMock{},
+		&writer,
+	)
+	err := nc.CaptureRoleObjects([]string{"role[role1]"})
+	if assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "unable to retrieve")
+		assert.Contains(t, err.Error(), "failed to fetch")
+	}
+}
+
+func TestCaptureRoleObjectsWithErrorOnSave(t *testing.T) {
+	writer := ObjectWriterMock{Error: errors.New("failed to write")}
+	nc := subject.NewNodeCapture("",
+		"",
+		NodeMock{},
+		RoleMock{},
+		EnvMock{},
+		CookbookMock{},
+		&writer,
+	)
+	err := nc.CaptureRoleObjects([]string{"role[role1]"})
+	if assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "failed to save role")
+		assert.Contains(t, err.Error(), "failed to write")
+	}
+}
+
+func TestCaptureEnvObject(t *testing.T) {
+	expectedEnv := chef.Environment{
+		Name: "env1",
+	}
+	writer := ObjectWriterMock{}
+	nc := subject.NewNodeCapture("", "",
+		NodeMock{},
+		RoleMock{},
+		EnvMock{Env: &expectedEnv},
+		CookbookMock{},
+		&writer,
+	)
+	err := nc.CaptureEnvObject("env1")
+	assert.Equal(t, writer.ReceivedObject, &expectedEnv)
+	assert.Nil(t, err)
+}
+
+func TestCaptureEnvObjectWithErrorOnFetch(t *testing.T) {
+	writer := ObjectWriterMock{}
+	nc := subject.NewNodeCapture("",
+		"",
+		NodeMock{},
+		RoleMock{},
+		EnvMock{Error: errors.New("failed to fetch")},
+		CookbookMock{},
+		&writer,
+	)
+	err := nc.CaptureEnvObject("env1")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch")
+}
+
+func TestCaptureEnvObjectWithErrorOnSave(t *testing.T) {
+	writer := ObjectWriterMock{Error: errors.New("failed to write")}
+	nc := subject.NewNodeCapture("",
+		"",
+		NodeMock{},
+		RoleMock{},
+		EnvMock{},
+		CookbookMock{},
+		&writer,
+	)
+	err := nc.CaptureEnvObject("env1")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "failed to write")
+
+}
+
+func TestCaptureCookbooks(t *testing.T) {
+	baseDir, err := ioutil.TempDir(os.TempDir(), "chefanalyze-unit*")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(baseDir)
+
+	cookbookList := chef.CookbookListResult{
+		"foo": chef.CookbookVersions{
+			Versions: []chef.CookbookVersion{
+				chef.CookbookVersion{Version: "0.1.0"},
+			},
+		},
+	}
+
+	writer := ObjectWriterMock{}
+	nc := subject.NewNodeCapture("temp", baseDir,
+		NodeMock{},
+		RoleMock{},
+		EnvMock{},
+		newMockCookbook(cookbookList, nil, nil),
+		&writer,
+	)
+
+	cbmap := map[string]interface{}{
+		"foo": map[string]interface{}{
+			"version": "0.1.0",
+		},
+	}
+
+	err = nc.CaptureCookbooks(cbmap)
+	assert.Nil(t, err)
+}
+
+func TestCaptureCookbooksWithDownloadError(t *testing.T) {
+	baseDir, err := ioutil.TempDir(os.TempDir(), "chefanalyze-unit*")
+	if err != nil {
+		panic(err)
+	}
+	assert.Nil(t, err)
+	defer os.RemoveAll(baseDir)
+
+	cookbookList := chef.CookbookListResult{
+		"foo": chef.CookbookVersions{
+			Versions: []chef.CookbookVersion{
+				chef.CookbookVersion{Version: "0.1.0"},
+			},
+		},
+	}
+
+	writer := ObjectWriterMock{}
+	nc := subject.NewNodeCapture("temp", baseDir,
+		NodeMock{},
+		RoleMock{},
+		EnvMock{},
+		newMockCookbook(cookbookList, nil, errors.New("download error in test1")),
+		&writer,
+	)
+
+	cookbookPath := fmt.Sprintf("%s/cookbooks/foo-0.1.0", baseDir)
+	// pre-setup to ensure that the rename of the downloaded cookbook (foo-0.1.0 to foo)
+	// will succeed; required because the cookbook mock doesn't perform an actual download
+	err = os.MkdirAll(cookbookPath, 0755)
+	if err != nil {
+		panic(err)
+	}
+
+	cbmap := map[string]interface{}{
+		"foo": map[string]interface{}{
+			"version": "0.1.0",
+		},
+	}
+
+	err = nc.CaptureCookbooks(cbmap)
+	if assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "download error in test1")
+		assert.Contains(t, err.Error(), "Failed to download cookbook")
+	}
+}
+func TestCaptureCookbooksWithRenameError(t *testing.T) {
+	baseDir, err := ioutil.TempDir(os.TempDir(), "chefanalyze-unit*")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(baseDir)
+
+	cookbookList := chef.CookbookListResult{
+		"foo": chef.CookbookVersions{
+			Versions: []chef.CookbookVersion{
+				chef.CookbookVersion{Version: "0.1.0"},
+			},
+		},
+	}
+
+	writer := ObjectWriterMock{}
+	cbMock := newMockCookbook(cookbookList, nil, nil)
+	cbMock.createDirOnDownload = false
+	nc := subject.NewNodeCapture("temp", baseDir,
+		NodeMock{},
+		RoleMock{},
+		EnvMock{},
+		cbMock,
+		&writer,
+	)
+
+	// To force this error, we will not manually create the versioned cookbook
+	// directory name that a real download cookbooks would do. This will cause the
+	// rename to fail since the directory to be renamed won't exist.
+
+	cbmap := map[string]interface{}{
+		"foo": map[string]interface{}{
+			"version": "0.1.0",
+		},
+	}
+
+	err = nc.CaptureCookbooks(cbmap)
+	if assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "failed to rename cookbook")
+	}
+}

--- a/pkg/reporting/capture_test.go
+++ b/pkg/reporting/capture_test.go
@@ -28,6 +28,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCaptureRun(t *testing.T) {
+	expectedNode := chef.Node{
+		Name:        "node1",
+		Environment: "_default",
+		RunList:     []string{"cookbook1::recipe1", "role:mockrole"},
+		PolicyName:  "",
+		PolicyGroup: "",
+	}
+	writer := ObjectWriterMock{}
+	nc := subject.NewNodeCapture("",
+		"",
+		NodeMock{Error: nil, Node: expectedNode},
+		RoleMock{},
+		EnvMock{},
+		CookbookMock{},
+		&writer,
+	)
+	actualNode, err := nc.CaptureNodeObject()
+	assert.Equal(t, &expectedNode, actualNode)
+	assert.Equal(t, &expectedNode, writer.ReceivedObject)
+	assert.Equal(t, nil, err)
+}
+
 func TestCaptureNodeObject(t *testing.T) {
 	expectedNode := chef.Node{
 		Name:        "node1",
@@ -88,6 +111,7 @@ func TestCaptureNodeObjectWithErrorOnFetch(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "fetch error") // because it's wrapped
 }
+
 func TestCaptureNodeObjectWithErrorOnSave(t *testing.T) {
 	node := chef.Node{}
 	writer := ObjectWriterMock{Error: errors.New("failed to write")}

--- a/pkg/reporting/client.go
+++ b/pkg/reporting/client.go
@@ -34,11 +34,11 @@ type SearchInterface interface {
 }
 
 type NodesInterface interface {
-	Get(name string) (node chef.Node, err error)
+	Get(name string) (chef.Node, error)
 }
 type RolesInterface interface {
-	Get(name string) (node *chef.Role, err error)
+	Get(name string) (*chef.Role, error)
 }
 type EnvironmentInterface interface {
-	Get(name string) (node *chef.Environment, err error)
+	Get(name string) (*chef.Environment, error)
 }

--- a/pkg/reporting/client.go
+++ b/pkg/reporting/client.go
@@ -32,3 +32,13 @@ type CookbookInterface interface {
 type SearchInterface interface {
 	PartialExec(idx, statement string, params map[string]interface{}) (res chef.SearchResult, err error)
 }
+
+type NodesInterface interface {
+	Get(name string) (node chef.Node, err error)
+}
+type RolesInterface interface {
+	Get(name string) (node *chef.Role, err error)
+}
+type EnvironmentInterface interface {
+	Get(name string) (node *chef.Environment, err error)
+}

--- a/pkg/reporting/object_writer.go
+++ b/pkg/reporting/object_writer.go
@@ -30,6 +30,12 @@ type ObjectWriter struct {
 	RootDir string
 }
 
+type ObjectWriterInterface interface {
+	WriteRole(*chef.Role) error
+	WriteEnvironment(*chef.Environment) error
+	WriteNode(*chef.Node) error
+}
+
 func (ow *ObjectWriter) WriteRole(role *chef.Role) error {
 	return ow.save("roles", role.Name, role)
 }

--- a/pkg/reporting/object_writer.go
+++ b/pkg/reporting/object_writer.go
@@ -36,19 +36,22 @@ type ObjectWriterInterface interface {
 	WriteNode(*chef.Node) error
 }
 
+// Takes a chef.Role and saves it as json in RootDir/roles
 func (ow *ObjectWriter) WriteRole(role *chef.Role) error {
-	return ow.save("roles", role.Name, role)
+	return ow.WriteJSON("roles", role.Name, role)
 }
 
+// Takes a chef.Role and saves it as json in RootDir/environments
 func (ow *ObjectWriter) WriteEnvironment(env *chef.Environment) error {
-	return ow.save("environments", env.Name, env)
+	return ow.WriteJSON("environments", env.Name, env)
 }
 
+// Takes a chef.Role and saves it as json in RootDir/nodes
 func (ow *ObjectWriter) WriteNode(node *chef.Node) error {
-	return ow.save("nodes", node.Name, node)
+	return ow.WriteJSON("nodes", node.Name, node)
 }
 
-func (ow *ObjectWriter) save(objGroupingName string, objName string, object interface{}) error {
+func (ow *ObjectWriter) WriteJSON(objGroupingName string, objName string, object interface{}) error {
 	var err error
 	dirName := fmt.Sprintf("%s/%s", ow.RootDir, objGroupingName)
 	path := fmt.Sprintf("%s/%s/%s.json", ow.RootDir, objGroupingName, objName)

--- a/pkg/reporting/object_writer.go
+++ b/pkg/reporting/object_writer.go
@@ -1,0 +1,70 @@
+//
+// Copyright 2020 Chef Software, Inc.
+// Author: Marc Paradise <marc@chef.io>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package reporting
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	chef "github.com/chef/go-chef"
+	"github.com/pkg/errors"
+)
+
+type ObjectWriter struct {
+	RootDir string
+}
+
+func (ow *ObjectWriter) WriteRole(role *chef.Role) error {
+	return ow.save("roles", role.Name, role)
+}
+
+func (ow *ObjectWriter) WriteEnvironment(env *chef.Environment) error {
+	return ow.save("environments", env.Name, env)
+}
+
+func (ow *ObjectWriter) WriteNode(node *chef.Node) error {
+	return ow.save("nodes", node.Name, node)
+}
+
+func (ow *ObjectWriter) save(objGroupingName string, objName string, object interface{}) error {
+	var err error
+	dirName := fmt.Sprintf("%s/%s", ow.RootDir, objGroupingName)
+	path := fmt.Sprintf("%s/%s/%s.json", ow.RootDir, objGroupingName, objName)
+	if _, err := os.Stat(dirName); os.IsNotExist(err) {
+		err = os.MkdirAll(dirName, 0700)
+	}
+	if err != nil {
+		return errors.Wrapf(err, "Failed to create directory %s", dirName)
+	}
+	body, err := chef.JSONReader(object)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to convert %s to json. If you see this, it's a bug.  Please report it.", objName)
+	}
+
+	content, err := ioutil.ReadAll(body)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to read %s %s", objGroupingName, objName)
+	}
+
+	err = ioutil.WriteFile(path, content, 0600)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to save file %s", path)
+	}
+	return nil
+}

--- a/pkg/reporting/object_writer_test.go
+++ b/pkg/reporting/object_writer_test.go
@@ -1,7 +1,48 @@
 package reporting_test
 
-import chef "github.com/chef/go-chef"
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
 
+	subject "github.com/chef/chef-analyze/pkg/reporting"
+	chef "github.com/chef/go-chef"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestObjectWriterWriteJSONObject(t *testing.T) {
+	baseDir, err := ioutil.TempDir(os.TempDir(), "chefanalyze-unit*")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(baseDir)
+
+	object := map[string]interface{}{
+		"attribute": map[string]interface{}{
+			"name":  "hello",
+			"value": "hello",
+		},
+	}
+	ow := subject.ObjectWriter{RootDir: baseDir}
+	err = ow.WriteJSON("groupname", "objectname", object)
+	if assert.Nil(t, err) {
+		// In addition to verifying the content is placed at the correct location,
+		// rading the file back in lets us verify Now make sure we get back the same content that we sent out.
+		content, err := ioutil.ReadFile(fmt.Sprintf("%s/groupname/objectname.json", baseDir))
+		assert.Nil(t, err)
+		var objmap map[string]interface{}
+
+		err = json.Unmarshal(content, &objmap)
+		assert.Nil(t, err)
+		assert.Equal(t, object, objmap)
+
+	}
+
+}
+
+// This mock is defined here for shared use in other tests.
 type ObjectWriterMock struct {
 	Error                 error
 	SavedRoleCount        int

--- a/pkg/reporting/object_writer_test.go
+++ b/pkg/reporting/object_writer_test.go
@@ -1,0 +1,32 @@
+package reporting_test
+
+import chef "github.com/chef/go-chef"
+
+type ObjectWriterMock struct {
+	Error                 error
+	SavedRoleCount        int
+	SavedEnvironmentCount int
+	SavedNodeCount        int
+	ReceivedObject        interface{}
+}
+
+func (ow *ObjectWriterMock) WriteRole(role *chef.Role) error {
+	if (ow.Error) == nil {
+		ow.ReceivedObject = role
+	}
+	return ow.Error
+}
+
+func (ow *ObjectWriterMock) WriteEnvironment(env *chef.Environment) error {
+	if (ow.Error) == nil {
+		ow.ReceivedObject = env
+	}
+	return ow.Error
+}
+
+func (ow *ObjectWriterMock) WriteNode(node *chef.Node) error {
+	if (ow.Error) == nil {
+		ow.ReceivedObject = node
+	}
+	return ow.Error
+}

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -375,6 +375,30 @@ var awsPartition = partition{
 						Region: "eu-west-3",
 					},
 				},
+				"fips-us-east-1": endpoint{
+					Hostname: "ecr-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "ecr-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "ecr-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "ecr-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
 				"me-south-1": endpoint{
 					Hostname: "api.ecr.me-south-1.amazonaws.com",
 					CredentialScope: credentialScope{
@@ -700,12 +724,42 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-ca-central-1": endpoint{
+					Hostname: "batch-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+				},
+				"fips-us-east-1": endpoint{
+					Hostname: "batch-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "batch-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "batch-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "batch-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"me-south-1": endpoint{},
+				"sa-east-1":  endpoint{},
+				"us-east-1":  endpoint{},
+				"us-east-2":  endpoint{},
+				"us-west-1":  endpoint{},
+				"us-west-2":  endpoint{},
 			},
 		},
 		"budgets": service{
@@ -892,12 +946,36 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-us-east-1": endpoint{
+					Hostname: "cloudtrail-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "cloudtrail-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "cloudtrail-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "cloudtrail-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"me-south-1": endpoint{},
+				"sa-east-1":  endpoint{},
+				"us-east-1":  endpoint{},
+				"us-east-2":  endpoint{},
+				"us-west-1":  endpoint{},
+				"us-west-2":  endpoint{},
 			},
 		},
 		"codebuild": service{
@@ -1382,8 +1460,9 @@ var awsPartition = partition{
 		"discovery": service{
 
 			Endpoints: endpoints{
-				"eu-central-1": endpoint{},
-				"us-west-2":    endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-central-1":   endpoint{},
+				"us-west-2":      endpoint{},
 			},
 		},
 		"dms": service{
@@ -1734,12 +1813,36 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-us-east-1": endpoint{
+					Hostname: "elasticloadbalancing-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "elasticloadbalancing-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "elasticloadbalancing-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "elasticloadbalancing-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"me-south-1": endpoint{},
+				"sa-east-1":  endpoint{},
+				"us-east-1":  endpoint{},
+				"us-east-2":  endpoint{},
+				"us-west-1":  endpoint{},
+				"us-west-2":  endpoint{},
 			},
 		},
 		"elasticmapreduce": service{
@@ -2290,10 +2393,34 @@ var awsPartition = partition{
 				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-us-east-1": endpoint{
+					Hostname: "inspector-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "inspector-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "inspector-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "inspector-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"us-east-1": endpoint{},
+				"us-east-2": endpoint{},
+				"us-west-1": endpoint{},
+				"us-west-2": endpoint{},
 			},
 		},
 		"iot": service{
@@ -2811,8 +2938,9 @@ var awsPartition = partition{
 		"mgh": service{
 
 			Endpoints: endpoints{
-				"eu-central-1": endpoint{},
-				"us-west-2":    endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-central-1":   endpoint{},
+				"us-west-2":      endpoint{},
 			},
 		},
 		"mobileanalytics": service{
@@ -4290,12 +4418,36 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-us-east-1": endpoint{
+					Hostname: "states-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "states-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "states-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "states-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"me-south-1": endpoint{},
+				"sa-east-1":  endpoint{},
+				"us-east-1":  endpoint{},
+				"us-east-2":  endpoint{},
+				"us-west-1":  endpoint{},
+				"us-west-2":  endpoint{},
 			},
 		},
 		"storagegateway": service{
@@ -4466,12 +4618,36 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-us-east-1": endpoint{
+					Hostname: "swf-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "swf-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "swf-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "swf-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"me-south-1": endpoint{},
+				"sa-east-1":  endpoint{},
+				"us-east-1":  endpoint{},
+				"us-east-2":  endpoint{},
+				"us-west-1":  endpoint{},
+				"us-west-2":  endpoint{},
 			},
 		},
 		"tagging": service{
@@ -4513,12 +4689,36 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-us-east-1": endpoint{
+					Hostname: "fips.transcribe.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "fips.transcribe.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "fips.transcribe.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "fips.transcribe.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"me-south-1": endpoint{},
+				"sa-east-1":  endpoint{},
+				"us-east-1":  endpoint{},
+				"us-east-2":  endpoint{},
+				"us-west-1":  endpoint{},
+				"us-west-2":  endpoint{},
 			},
 		},
 		"transcribestreaming": service{
@@ -5373,6 +5573,18 @@ var awsusgovPartition = partition{
 		"api.ecr": service{
 
 			Endpoints: endpoints{
+				"fips-us-gov-east-1": endpoint{
+					Hostname: "ecr-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
+				"fips-us-gov-west-1": endpoint{
+					Hostname: "ecr-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
 				"us-gov-east-1": endpoint{
 					Hostname: "api.ecr.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
@@ -5470,8 +5682,18 @@ var awsusgovPartition = partition{
 		"batch": service{
 
 			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				"us-gov-east-1": endpoint{
+					Hostname: "batch.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
+				"us-gov-west-1": endpoint{
+					Hostname: "batch.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
 			},
 		},
 		"clouddirectory": service{
@@ -5792,6 +6014,18 @@ var awsusgovPartition = partition{
 		"inspector": service{
 
 			Endpoints: endpoints{
+				"fips-us-gov-east-1": endpoint{
+					Hostname: "inspector-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
+				"fips-us-gov-west-1": endpoint{
+					Hostname: "inspector-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
 				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
@@ -6153,6 +6387,18 @@ var awsusgovPartition = partition{
 		"states": service{
 
 			Endpoints: endpoints{
+				"fips-us-gov-east-1": endpoint{
+					Hostname: "states-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
+				"fips-us-gov-west-1": endpoint{
+					Hostname: "states.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
 				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
@@ -6209,8 +6455,18 @@ var awsusgovPartition = partition{
 		"swf": service{
 
 			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
-				"us-gov-west-1": endpoint{},
+				"us-gov-east-1": endpoint{
+					Hostname: "swf.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
+				"us-gov-west-1": endpoint{
+					Hostname: "swf.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
 			},
 		},
 		"tagging": service{
@@ -6225,6 +6481,18 @@ var awsusgovPartition = partition{
 				Protocols: []string{"https"},
 			},
 			Endpoints: endpoints{
+				"fips-us-gov-east-1": endpoint{
+					Hostname: "fips.transcribe.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
+				"fips-us-gov-west-1": endpoint{
+					Hostname: "fips.transcribe.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
 				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.29.31"
+const SDKVersion = "1.29.32"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2,7 +2,7 @@
 github.com/BurntSushi/toml
 # github.com/VividCortex/ewma v1.1.1
 github.com/VividCortex/ewma
-# github.com/aws/aws-sdk-go v1.29.31
+# github.com/aws/aws-sdk-go v1.29.32
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/arn
 github.com/aws/aws-sdk-go/aws/awserr


### PR DESCRIPTION
This adds an initial `capture` command to `chef analyze`.

`chef analyze capture`  accepts a node as an argument and creates a chef repo
that contains:

* node object
* required cookbooks
* roles
* environments

![capture_068](https://user-images.githubusercontent.com/1130204/77117162-d808eb80-6a07-11ea-83c7-a82d0a731a66.png)
![capture_065](https://user-images.githubusercontent.com/1130204/77117163-d808eb80-6a07-11ea-9e25-bb489647a68b.png)

This scope of this change extends to creating and populating the chef repository,
but does not include configuring a node.

## Related
closes chef/chef-workstation#1017



Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
