### PR TITLE
Allow inlining literal client_key in credentials

### DIFF
--- a/pkg/reporting/chef_client_test.go
+++ b/pkg/reporting/chef_client_test.go
@@ -63,3 +63,19 @@ func TestNewChefClientCredsWithEmptyKey(t *testing.T) {
 		}
 	}
 }
+
+func TestNewChefClientCredsWithInlinedKey(t *testing.T) {
+	defer os.RemoveAll(createCredentialsConfig(t))
+
+	cfg, err := subject.NewDefault()
+	if assert.Nil(t, err) {
+		assert.NotNil(t, cfg)
+
+		// activate a profile that has an inlined key pem
+		err := cfg.SwitchProfile("inlined")
+		assert.Nil(t, err)
+
+		client, err := subject.NewChefClient(&cfg)
+		assert.NotNil(t, client)
+	}
+}

--- a/pkg/reporting/setup_test.go
+++ b/pkg/reporting/setup_test.go
@@ -95,6 +95,13 @@ chef_server_url = "chef-server.example.com/organizations/dev"
 client_name = "empty"
 client_key = "` + emptyPemPath + `"
 chef_server_url = "chef-server.example.com/organizations/empty"
+
+[inlined]
+client_name = "inlined"
+client_key ="""
+` + string(key()) + `
+"""
+chef_server_url = "chef-server.example.com/organizations/inlined"
 `)
 	)
 	err := ioutil.WriteFile(credsPath, creds, 0644)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

The credentials file is documented as being able to have the client key inlined as a TOML heredoc. go-libs correctly reads the heredoc; however, the current chef-analyze code assumes that the value read is always the path to a file. This change simply looks for the RSA header, and if present, assumes the key has been inlined.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes https://github.com/chef/go-libs/issues/11

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
