### PR TITLE
Generate a kitchen.yml as part of capture

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -99,9 +99,9 @@ can then be used to converge locally.`,
 				return errors.Wrap(err, "Could not remove pre-created repo content: example cookbook")
 			}
 
-			err = os.RemoveAll(fmt.Sprintf("%s/cookbooks/example", dirName))
+			err = os.RemoveAll(fmt.Sprintf("%s/data_bags/example", dirName))
 			if err != nil {
-				return errors.Wrap(err, "Could not remove pre-created repo content: example cookbook")
+				return errors.Wrap(err, "Could not remove pre-created repo content: example data bag")
 			}
 
 			capturer := reporting.NewNodeCapturer(
@@ -121,6 +121,8 @@ can then be used to converge locally.`,
 					fmt.Println(" - Capturing roles...")
 				case reporting.FetchingEnvironment:
 					fmt.Println(" - Capturing environment...")
+				case reporting.WritingKitchenConfig:
+					fmt.Println(" - Writing kitchen configuration...")
 				case reporting.FetchingComplete:
 				}
 			}

--- a/pkg/reporting/object_writer.go
+++ b/pkg/reporting/object_writer.go
@@ -34,6 +34,7 @@ type ObjectWriterInterface interface {
 	WriteRole(*chef.Role) error
 	WriteEnvironment(*chef.Environment) error
 	WriteNode(*chef.Node) error
+	WriteContent(string, []byte) error
 }
 
 // Takes a chef.Role and saves it as json in RootDir/roles
@@ -49,6 +50,20 @@ func (ow *ObjectWriter) WriteEnvironment(env *chef.Environment) error {
 // Takes a chef.Role and saves it as json in RootDir/nodes
 func (ow *ObjectWriter) WriteNode(node *chef.Node) error {
 	return ow.WriteJSON("nodes", node.Name, node)
+}
+
+// Writes "content" to RootDir/"fileName"
+func (ow *ObjectWriter) WriteContent(fileName string, content []byte) error {
+	path := fmt.Sprintf("%s/%s", ow.RootDir, fileName)
+	f, err := os.Create(path)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create %s", path)
+	}
+	_, err = f.Write(content)
+	if err != nil {
+		return errors.Wrapf(err, "failed to write to %s", path)
+	}
+	return nil
 }
 
 func (ow *ObjectWriter) WriteJSON(objGroupingName string, objName string, object interface{}) error {


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
In order to test against the captured node, it's necessary
to generate a kitchen.yml configuration appropriate for the node.

This change adds the generation of a kitchen.yml
as the last step of node capture. Currently it looks
at node attributes to determine the type of image to create,
but this is limited to platform-name+platform-version (eg ubuntu-18.04)

This is suitable for our initial set of cases, but we will need to add
more flexibility in determining the right image name and the provider
(currently always vagrant), and will need to add prompting in cases
where we can't determine the correct provider/image.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] ~I have updated the documentation accordingly.~
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
