### PR TITLE
Make infra flags common to report and capture sub commands

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -50,7 +50,7 @@ var (
 can then be used to converge locally.`,
 		RunE: func(_ *cobra.Command, args []string) error {
 			creds, err := credentials.FromViper(
-				reportsFlags.profile,
+				infraFlags.profile,
 				overrideCredentials(),
 			)
 			if err != nil {
@@ -64,7 +64,7 @@ can then be used to converge locally.`,
 			}
 
 			cfg := &reporting.Reporting{Credentials: creds}
-			if reportsFlags.noSSLverify {
+			if infraFlags.noSSLverify {
 				cfg.NoSSLVerify = true
 			}
 
@@ -158,6 +158,9 @@ can then be used to converge locally.`,
 	}
 )
 
+func init() {
+	addInfraFlagsToCommand(captureCmd)
+}
 func requestCookbookPathFullMessage(repoPath string, cookbooks []reporting.NodeCookbook) string {
 	fmt.Printf(CookbookCaptureGatherSourcesTxt, repoPath, formatCookbooks(cookbooks))
 	var path string

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -45,4 +45,20 @@ const (
   To re-run capture for node %s, delete this directory.
 
 `
+	// Arg: 1 - feature flag name
+	//      2 - env var name
+	//      3 - feature flag name
+	AnalyzeNotEnabledE003 = `
+  E003
+
+	'%s' is experimental and in development. You can temporarily
+	enable it by setting the following environment variable:
+
+	  %s=true
+
+	Or permanently enable it by modifying $HOME/.chef-workstation/config.toml:
+
+	  [features]
+		%s = true
+`
 )

--- a/cmd/infra_flags.go
+++ b/cmd/infra_flags.go
@@ -44,15 +44,15 @@ func addInfraFlagsToCommand(cmd *cobra.Command) {
 			dist.UserConfDir),
 	)
 	cmd.PersistentFlags().StringVarP(
-		&infraFlags.clientName, "client_name", "n", "",
+		&infraFlags.clientName, "client-name", "n", "",
 		fmt.Sprintf("%s API client name", dist.ServerProduct),
 	)
 	cmd.PersistentFlags().StringVarP(
-		&infraFlags.clientKey, "client_key", "k", "",
+		&infraFlags.clientKey, "client-key", "k", "",
 		fmt.Sprintf("%s API client key", dist.ServerProduct),
 	)
 	cmd.PersistentFlags().StringVarP(
-		&infraFlags.chefServerURL, "chef_server_url", "s", "",
+		&infraFlags.chefServerURL, "chef-server-url", "s", "",
 		fmt.Sprintf("%s URL", dist.ServerProduct),
 	)
 	cmd.PersistentFlags().StringVarP(

--- a/cmd/infra_flags.go
+++ b/cmd/infra_flags.go
@@ -1,0 +1,69 @@
+// Copyright 2020 Chef Software, Inc.
+// Author: Salim Afiune <afiune@chef.io>
+// Author: Marc Paradise <marc@chef.io>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/chef/chef-analyze/pkg/dist"
+	"github.com/spf13/cobra"
+)
+
+var infraFlags struct {
+	credsFile     string
+	clientName    string
+	clientKey     string
+	chefServerURL string
+	profile       string
+	noSSLverify   bool
+}
+
+// Adds common chef-infra flags to the given command
+func addInfraFlagsToCommand(cmd *cobra.Command) {
+
+	// global report commands infraFlags
+	cmd.PersistentFlags().StringVarP(
+		&infraFlags.credsFile,
+		"credentials", "c", "",
+		fmt.Sprintf("credentials file (default $HOME/%s/credentials)",
+			dist.UserConfDir),
+	)
+	cmd.PersistentFlags().StringVarP(
+		&infraFlags.clientName, "client_name", "n", "",
+		fmt.Sprintf("%s API client name", dist.ServerProduct),
+	)
+	cmd.PersistentFlags().StringVarP(
+		&infraFlags.clientKey, "client_key", "k", "",
+		fmt.Sprintf("%s API client key", dist.ServerProduct),
+	)
+	cmd.PersistentFlags().StringVarP(
+		&infraFlags.chefServerURL, "chef_server_url", "s", "",
+		fmt.Sprintf("%s URL", dist.ServerProduct),
+	)
+	cmd.PersistentFlags().StringVarP(
+		&infraFlags.profile,
+		"profile", "p", "default",
+		"profile to use from credentials file",
+	)
+	cmd.PersistentFlags().BoolVarP(
+		&infraFlags.noSSLverify,
+		"ssl-no-verify", "o", false,
+		fmt.Sprintf("Do not verify SSL when connecting to %s (default: verify)",
+			dist.ServerProduct),
+	)
+}

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -65,7 +65,7 @@ provided when the report is generated.
 `,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			creds, err := credentials.FromViper(
-				reportsFlags.profile,
+				infraFlags.profile,
 				overrideCredentials(),
 			)
 
@@ -79,7 +79,7 @@ provided when the report is generated.
 			}
 
 			cfg := &reporting.Reporting{Credentials: creds}
-			if reportsFlags.noSSLverify {
+			if infraFlags.noSSLverify {
 				cfg.NoSSLVerify = true
 			}
 
@@ -151,7 +151,7 @@ provided when the report is generated.
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			creds, err := credentials.FromViper(
-				reportsFlags.profile,
+				infraFlags.profile,
 				overrideCredentials(),
 			)
 
@@ -165,7 +165,7 @@ provided when the report is generated.
 			}
 
 			cfg := &reporting.Reporting{Credentials: creds}
-			if reportsFlags.noSSLverify {
+			if infraFlags.noSSLverify {
 				cfg.NoSSLVerify = true
 			}
 
@@ -215,54 +215,20 @@ provided when the report is generated.
 		workers      int
 	}
 	reportsFlags struct {
-		credsFile     string
-		clientName    string
-		clientKey     string
-		chefServerURL string
-		profile       string
-		noSSLverify   bool
-		format        string
-		nodeFilter    string
+		format     string
+		nodeFilter string
 	}
 )
 
 func init() {
-	// global report commands flags
-	reportCmd.PersistentFlags().StringVarP(
-		&reportsFlags.credsFile,
-		"credentials", "c", "",
-		fmt.Sprintf("credentials file (default $HOME/%s/credentials)", dist.UserConfDir),
-	)
+	// Add shared infra/chef-server related flags
+	addInfraFlagsToCommand(reportCmd)
 
+	// common report flags
 	reportCmd.PersistentFlags().StringVarP(
 		&reportsFlags.format,
 		"format", "f", "txt",
 		"output format: txt is human readable, csv is machine readable",
-	)
-	reportCmd.PersistentFlags().StringVarP(
-		&reportsFlags.clientName,
-		"client_name", "n", "",
-		fmt.Sprintf("%s API client username", dist.ServerProduct),
-	)
-	reportCmd.PersistentFlags().StringVarP(
-		&reportsFlags.clientKey,
-		"client_key", "k", "",
-		fmt.Sprintf("%s API client key", dist.ServerProduct),
-	)
-	reportCmd.PersistentFlags().StringVarP(
-		&reportsFlags.chefServerURL,
-		"chef_server_url", "s", "",
-		fmt.Sprintf("%s URL", dist.ServerProduct),
-	)
-	reportCmd.PersistentFlags().StringVarP(
-		&reportsFlags.profile,
-		"profile", "p", "default",
-		fmt.Sprintf("%s URL", dist.ServerProduct),
-	)
-	reportCmd.PersistentFlags().BoolVarP(
-		&reportsFlags.noSSLverify,
-		"ssl-no-verify", "o", false,
-		"Disable SSL certificate verification",
 	)
 	reportCmd.PersistentFlags().StringVarP(
 		&reportsFlags.nodeFilter,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,9 +76,9 @@ func init() {
 }
 
 func initConfig() {
-	if reportsFlags.credsFile != "" {
+	if infraFlags.credsFile != "" {
 		// Use credentials file from the flag
-		viper.SetConfigFile(reportsFlags.credsFile)
+		viper.SetConfigFile(infraFlags.credsFile)
 	} else {
 		// Find the credentials and pass it to viper
 		credsFile, err := credentials.FindCredentialsFile()
@@ -108,9 +108,9 @@ func initConfig() {
 // this tool to work, with or without credentials config
 // TODO @afiune revisit
 func hasMinimumParams() bool {
-	if reportsFlags.chefServerURL != "" &&
-		reportsFlags.clientName != "" &&
-		reportsFlags.clientKey != "" {
+	if infraFlags.chefServerURL != "" &&
+		infraFlags.clientName != "" &&
+		infraFlags.clientKey != "" {
 		return true
 	}
 
@@ -138,14 +138,14 @@ func isHelpCommand() bool {
 // overrides the credentials from the viper bound flags
 func overrideCredentials() credentials.OverrideFunc {
 	return func(c *credentials.Credentials) {
-		if reportsFlags.clientName != "" {
-			c.ClientName = reportsFlags.clientName
+		if infraFlags.clientName != "" {
+			c.ClientName = infraFlags.clientName
 		}
-		if reportsFlags.clientKey != "" {
-			c.ClientKey = reportsFlags.clientKey
+		if infraFlags.clientKey != "" {
+			c.ClientKey = infraFlags.clientKey
 		}
-		if reportsFlags.chefServerURL != "" {
-			c.ChefServerUrl = reportsFlags.chefServerURL
+		if infraFlags.chefServerURL != "" {
+			c.ChefServerUrl = infraFlags.chefServerURL
 		}
 	}
 }

--- a/integration/featflag_test.go
+++ b/integration/featflag_test.go
@@ -30,15 +30,16 @@ func TestFeatureFlag(t *testing.T) {
 		"STDERR should be empty")
 	assert.Equal(t, 0, exitcode,
 		"EXITCODE is not the expected one")
-
-	// assert the feature flag message to the end user
+	assert.Contains(t, out.String(),
+		"E003",
+		"STDOUT does not contain expected error code")
 	assert.Contains(t,
 		out.String(),
-		"`analyze` is experimental and in development.",
+		"'analyze' is experimental and in development.",
 		"STDOUT message doesn't match")
 	assert.Contains(t,
 		out.String(),
-		"Temporarily enable `analyze` with the environment variable:",
+		"enable it by setting the following environment variable:",
 		"STDOUT message doesn't match")
 	assert.Contains(t,
 		out.String(),
@@ -46,7 +47,7 @@ func TestFeatureFlag(t *testing.T) {
 		"STDOUT message doesn't match")
 	assert.Contains(t,
 		out.String(),
-		"Or, permanently by modifying $HOME/.chef-workstation/config.toml with:",
+		"permanently enable it by modifying $HOME/.chef-workstation/config.toml",
 		"STDOUT message doesn't match")
 	assert.Contains(t,
 		out.String(),

--- a/integration/help_test.go
+++ b/integration/help_test.go
@@ -78,14 +78,14 @@ func TestHelpNoArgs(t *testing.T) {
 func TestHelpCommandDisplayHelpFromCommand(t *testing.T) {
 	out, err, exitcode := ChefAnalyze("help", "report")
 	assert.Contains(t, out.String(),
-		"--chef_server_url",
-		"STDOUT chef_server_url flag doesn't exist")
+		"--chef-server-url",
+		"STDOUT chef-server-url flag doesn't exist")
 	assert.Contains(t, out.String(),
-		"--client_key",
-		"STDOUT client_key flag doesn't exist")
+		"--client-key",
+		"STDOUT client-key flag doesn't exist")
 	assert.Contains(t, out.String(),
-		"--client_name",
-		"STDOUT client_name flag doesn't exist")
+		"--client-name",
+		"STDOUT client-name flag doesn't exist")
 	assert.Contains(t, out.String(),
 		"--credentials",
 		"STDOUT credentials flag doesn't exist")

--- a/integration/help_test.go
+++ b/integration/help_test.go
@@ -74,8 +74,30 @@ func TestHelpNoArgs(t *testing.T) {
 	assert.Equal(t, 0, exitcode,
 		"EXITCODE is not the expected one")
 }
+func TestHelpCommandDisplayHelpForCapture(t *testing.T) {
+	out, err, exitcode := ChefAnalyze("help", "capture")
 
-func TestHelpCommandDisplayHelpFromCommand(t *testing.T) {
+	var expected = `Captures a node's state as a local chef-repo, which
+can then be used to converge locally.
+
+Usage:
+  chef-analyze capture NODE-NAME [flags]
+
+Flags:
+  -s, --chef-server-url string   Chef Infra Server URL
+  -k, --client-key string        Chef Infra Server API client key
+  -n, --client-name string       Chef Infra Server API client name
+  -c, --credentials string       credentials file (default $HOME/.chef/credentials)
+  -h, --help                     help for capture
+  -p, --profile string           profile to use from credentials file (default "default")
+  -o, --ssl-no-verify            Do not verify SSL when connecting to Chef Infra Server (default: verify)
+`
+	assert.Equal(t, expected, out.String())
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+}
+
+func TestHelpCommandDisplayHelpForReport(t *testing.T) {
 	out, err, exitcode := ChefAnalyze("help", "report")
 	assert.Contains(t, out.String(),
 		"--chef-server-url",
@@ -95,6 +117,9 @@ func TestHelpCommandDisplayHelpFromCommand(t *testing.T) {
 	assert.Contains(t, out.String(),
 		"--profile",
 		"STDOUT profile flag doesn't exist")
+	assert.Contains(t, out.String(),
+		"--format string",
+		"STDOUT format string flag doesn't exist")
 	assert.Contains(t,
 		out.String(),
 		"chef-analyze report [command]",
@@ -104,6 +129,72 @@ func TestHelpCommandDisplayHelpFromCommand(t *testing.T) {
 		"STDERR should be empty")
 	assert.Equal(t, 0, exitcode,
 		"EXITCODE is not the expected one")
+}
+
+func TestHelpCommandDisplayHelpForReportCookbooks(t *testing.T) {
+	out, err, exitcode := ChefAnalyze("help", "report", "cookbooks")
+	var expected = `Generates cookbook oriented reports containing details about the number of
+violations each cookbook has, which violations can be are auto-corrected and
+the number of nodes using each cookbook.
+
+These reports could take a long time to run depending on the number of cookbooks
+to analyze and therefore reports will be written to disk. The location will be
+provided when the report is generated.
+
+Usage:
+  chef-analyze report cookbooks [flags]
+
+Flags:
+  -h, --help             help for cookbooks
+  -u, --only-unused      generate a report with only cookbooks that are not included in any node's runlist
+  -V, --verify-upgrade   verify the upgrade compatibility of every cookbook
+  -w, --workers int      maximum number of parallel workers at once (default 50)
+
+Global Flags:
+  -s, --chef-server-url string   Chef Infra Server URL
+  -k, --client-key string        Chef Infra Server API client key
+  -n, --client-name string       Chef Infra Server API client name
+  -c, --credentials string       credentials file (default $HOME/.chef/credentials)
+  -f, --format string            output format: txt is human readable, csv is machine readable (default "txt")
+  -F, --node-filter string       Search filter to apply to nodes
+  -p, --profile string           profile to use from credentials file (default "default")
+  -o, --ssl-no-verify            Do not verify SSL when connecting to Chef Infra Server (default: verify)
+`
+	assert.Equal(t, out.String(), expected)
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one")
+}
+
+func TestHelpCommandDisplayHelpForReportNodes(t *testing.T) {
+	out, err, exitcode := ChefAnalyze("help", "report", "nodes")
+	var expected = `Generates a nodes oriented report
+
+Usage:
+  chef-analyze report nodes [flags]
+
+Flags:
+  -h, --help   help for nodes
+
+Global Flags:
+  -s, --chef-server-url string   Chef Infra Server URL
+  -k, --client-key string        Chef Infra Server API client key
+  -n, --client-name string       Chef Infra Server API client name
+  -c, --credentials string       credentials file (default $HOME/.chef/credentials)
+  -f, --format string            output format: txt is human readable, csv is machine readable (default "txt")
+  -F, --node-filter string       Search filter to apply to nodes
+  -p, --profile string           profile to use from credentials file (default "default")
+  -o, --ssl-no-verify            Do not verify SSL when connecting to Chef Infra Server (default: verify)
+`
+	assert.Equal(t, out.String(), expected)
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one")
+
 }
 
 func TestHelpCommandDisplayHelpFromUnknownCommand(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -31,10 +31,7 @@ func main() {
 			os.Exit(-1)
 		}
 	} else {
-		fmt.Printf("`%s` is experimental and in development.\n\n", featflag.ChefFeatAnalyze.Key())
-		fmt.Printf("Temporarily enable `%s` with the environment variable:\n", featflag.ChefFeatAnalyze.Key())
-		fmt.Printf("\t%s=true\n\n", featflag.ChefFeatAnalyze.Env())
-		fmt.Printf("Or, permanently by modifying $HOME/.chef-workstation/config.toml with:\n")
-		fmt.Printf("\t[features]\n\t%s = true\n", featflag.ChefFeatAnalyze.Key())
+		key := featflag.ChefFeatAnalyze.Key()
+		fmt.Printf(cmd.AnalyzeNotEnabledE003, key, featflag.ChefFeatAnalyze.Env(), key)
 	}
 }


### PR DESCRIPTION

## Description
1. Adds support for the chef-server/infra related flags (like --chef-server-url) to the `capture` command by moving it to be shared across report and capture. 
2. Cleans up minor inconsistencies in flag names (dash instead of underscore)
3. Adds integration tests for help output of capture, report nodes, report cookbooks. 
4. Moves long feature flag disabled error message into `cmd/error`. Minor corrections to the text. Gave it its very own error number. 

## Related Issue
closes #239 
