### PR TITLE
Support use as `chef report` and `chef capture`

### DIFF
--- a/cmd/report.go
+++ b/cmd/report.go
@@ -252,13 +252,16 @@ func init() {
 		"verify the upgrade compatibility of every cookbook",
 	)
 	// adds the cookbooks command as a sub-command of the report command
-	// => chef-analyze report cookbooks
 	reportCmd.AddCommand(reportCookbooksCmd)
 
 	// adds the nodes command as a sub-command of the report command
-	// => chef-analyze report nodes
 	reportCmd.AddCommand(reportNodesCmd)
 
+	// adds the upload command as a hidden sub-command of the report command
+	reportCmd.AddCommand(uploadCmd)
+
+	// adds the session command as a hidden sub-command of the report command
+	reportCmd.AddCommand(sessionCmd)
 }
 
 func createOutputDirectories() error {

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -53,15 +53,12 @@ var (
 	}
 	reportCookbooksCmd = &cobra.Command{
 		Use:   "cookbooks",
-		Short: "Generates a cookbook oriented report",
+		Short: "Generates a cookbook-oriented report",
 		Args:  cobra.NoArgs,
-		Long: `Generates cookbook oriented reports containing details about the number of
-violations each cookbook has, which violations can be are auto-corrected and
-the number of nodes using each cookbook.
+		Long: `Generates a cookbook-oriented report containing details about the
+upgrade compatibility errors and node cookbook usage.
 
-These reports could take a long time to run depending on the number of cookbooks
-to analyze and therefore reports will be written to disk. The location will be
-provided when the report is generated.
+The result is written to file.
 `,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			creds, err := credentials.FromViper(
@@ -147,8 +144,10 @@ provided when the report is generated.
 	}
 	reportNodesCmd = &cobra.Command{
 		Use:   "nodes",
-		Short: "Generates a nodes oriented report",
-		Args:  cobra.NoArgs,
+		Short: "Generates a nodes-oriented report",
+		Long: `Generates a nodes-oriented report containing basic information about the node,
+any applied policies, and the cookbooks used during the most recent chef-client run`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			creds, err := credentials.FromViper(
 				infraFlags.profile,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,20 +33,19 @@ var (
 		// This is intended to be used as part of Workstation, via the `chef` command
 		// but will also support other wrappers via dist.CLIWrapperExec.
 		Use:   fmt.Sprintf("%s report", dist.CLIWrapperExec),
-		Short: fmt.Sprintf("Generate reports from a %s", dist.ServerProduct),
-		Long: fmt.Sprintf(`Reports to assist you in understanding the effort to
-upgrade your infrastructure to latest patterns and practices.
-Can aggregate information by nodes or cookbooks.`),
+		Short: fmt.Sprintf("Please use the '%s' executable to access Upgrade Lab features", dist.CLIWrapperExec),
 	}
 )
 
 // Execute runs the root command
 func Execute() error {
+	msg := fmt.Sprintf("Please use the '%s' executable to access Upgrade Lab features.\n", dist.CLIWrapperExec)
 	rootCmd.RunE = func(_ *cobra.Command, args []string) error {
-		// The top level command print usage and exit-non-zero.
-		// By default it will exit non-zero, so we override the behavior here
-		// by not returning an error.
-		rootCmd.Help()
+		fmt.Printf(msg)
+		return nil
+	}
+	if isHelpCommand() {
+		fmt.Printf(msg)
 		return nil
 	}
 	return rootCmd.Execute()
@@ -117,19 +116,17 @@ func isReportCommand() bool {
 	if len(os.Args) <= 1 {
 		return false
 	}
-	if os.Args[1] == "report" {
-		return true
-	}
-	return false
+	return os.Args[1] == "report"
 }
+
+// returns true if this is a top-level request for help.
+// Will return false if not help-related, or is a subcommand help option
+// eg chef-analyze reports help
 func isHelpCommand() bool {
-	if len(os.Args) <= 1 {
+	if len(os.Args) != 2 {
 		return false
 	}
-	if os.Args[1] == "help" {
-		return true
-	}
-	return false
+	return os.Args[1] == "help" || os.Args[1] == "-h" || os.Args[1] == "--help"
 }
 
 // overrides the credentials from the viper bound flags

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,10 +68,6 @@ func init() {
 	rootCmd.AddCommand(reportCmd)
 	// adds the config command from 'cmd/config.go'
 	rootCmd.AddCommand(configCmd)
-	// adds the upload command from 'cmd/upload.go'
-	rootCmd.AddCommand(uploadCmd)
-	// adds the session command from 'cmd/session.go'
-	rootCmd.AddCommand(sessionCmd)
 	// adds the capture command from 'cmd/capture.go'
 	rootCmd.AddCommand(captureCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,12 +30,13 @@ import (
 
 var (
 	rootCmd = &cobra.Command{
-		Use:   dist.AnalyzeExec,
-		Short: fmt.Sprintf("A CLI to analyze artifacts from a %s", dist.ServerProduct),
-		Long: fmt.Sprintf(`Analyze your %s artifacts to understand the effort to upgrade
-your infrastructure by generating reports, automatically fixing violations
-and/or deprecations, and generating Effortless packages.
-`, dist.ServerProduct),
+		// This is intended to be used as part of Workstation, via the `chef` command
+		// but will also support other wrappers via dist.CLIWrapperExec.
+		Use:   fmt.Sprintf("%s report", dist.CLIWrapperExec),
+		Short: fmt.Sprintf("Generate reports from a %s", dist.ServerProduct),
+		Long: fmt.Sprintf(`Reports to assist you in understanding the effort to
+upgrade your infrastructure to latest patterns and practices.
+Can aggregate information by nodes or cookbooks.`),
 	}
 )
 

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -29,9 +29,9 @@ import (
 
 var (
 	sessionCmd = &cobra.Command{
-		Use:    "session [MINUTES]",
+		Use:    "session MINUTES",
 		Hidden: true,
-		Short:  fmt.Sprintf("Creates new access credentials to upload files to %s", dist.CompanyName),
+		Short:  fmt.Sprintf("Creates new access credentials to upload files to %s. Expires in MINUTES.", dist.CompanyName),
 		Args:   cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			min, err := strconv.ParseInt(args[0], 10, 64)

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -31,6 +31,7 @@ var (
 		Aliases: []string{"upload"},
 		Short:   fmt.Sprintf("Upload a file to %s", dist.CompanyName),
 		Args:    cobra.ExactArgs(2),
+		Hidden:  true,
 		RunE: func(_ *cobra.Command, args []string) error {
 			// cobra will make sure we always have exactly 2 arguments
 			return UploadToS3(args[0], args[1])

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -27,9 +27,10 @@ import (
 
 var (
 	uploadCmd = &cobra.Command{
-		Use:   "upload [LOCATION] [FILE]",
-		Short: fmt.Sprintf("Upload a file to %s", dist.CompanyName),
-		Args:  cobra.ExactArgs(2),
+		Use:     "report upload LOCATION FILE",
+		Aliases: []string{"upload"},
+		Short:   fmt.Sprintf("Upload a file to %s", dist.CompanyName),
+		Args:    cobra.ExactArgs(2),
 		RunE: func(_ *cobra.Command, args []string) error {
 			// cobra will make sure we always have exactly 2 arguments
 			return UploadToS3(args[0], args[1])

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -27,11 +27,10 @@ import (
 
 var (
 	uploadCmd = &cobra.Command{
-		Use:     "report upload LOCATION FILE",
-		Aliases: []string{"upload"},
-		Short:   fmt.Sprintf("Upload a file to %s", dist.CompanyName),
-		Args:    cobra.ExactArgs(2),
-		Hidden:  true,
+		Use:    "report upload LOCATION FILE",
+		Short:  fmt.Sprintf("Upload FILE to named LOCATION for %s to review", dist.CompanyName),
+		Args:   cobra.ExactArgs(2),
+		Hidden: true,
 		RunE: func(_ *cobra.Command, args []string) error {
 			// cobra will make sure we always have exactly 2 arguments
 			return UploadToS3(args[0], args[1])

--- a/integration/help_test.go
+++ b/integration/help_test.go
@@ -25,54 +25,30 @@ import (
 
 func TestHelpCommand(t *testing.T) {
 	out, err, exitcode := ChefAnalyze("help")
-	assert.Contains(t,
-		out.String(),
-		"Use \"chef [command] --help\" for more information about a command.",
-		"STDOUT bottom message doesn't match")
-	assert.Empty(t,
-		err.String(),
-		"STDERR should be empty")
-	assert.Equal(t, 0, exitcode,
-		"EXITCODE is not the expected one")
+	assert.Equal(t, "Please use the 'chef' executable to access Upgrade Lab features.\n", out.String())
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }
 
 func TestHelpFlags_h(t *testing.T) {
 	out, err, exitcode := ChefAnalyze("-h")
-	assert.Contains(t,
-		out.String(),
-		"Use \"chef [command] --help\" for more information about a command.",
-		"STDOUT bottom message doesn't match")
-	assert.Empty(t,
-		err.String(),
-		"STDERR should be empty")
-	assert.Equal(t, 0, exitcode,
-		"EXITCODE is not the expected one")
+	assert.Equal(t, "Please use the 'chef' executable to access Upgrade Lab features.\n", out.String())
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }
 
 func TestHelpFlags__help(t *testing.T) {
 	out, err, exitcode := ChefAnalyze("--help")
-	assert.Contains(t,
-		out.String(),
-		"Use \"chef [command] --help\" for more information about a command.",
-		"STDOUT bottom message doesn't match")
-	assert.Empty(t,
-		err.String(),
-		"STDERR should be empty")
-	assert.Equal(t, 0, exitcode,
-		"EXITCODE is not the expected one")
+	assert.Equal(t, "Please use the 'chef' executable to access Upgrade Lab features.\n", out.String())
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }
 
 func TestHelpNoArgs(t *testing.T) {
 	out, err, exitcode := ChefAnalyze()
-	assert.Contains(t,
-		out.String(),
-		"Use \"chef [command] --help\" for more information about a command.",
-		"STDOUT bottom message doesn't match")
-	assert.Empty(t,
-		err.String(),
-		"STDERR should be empty")
-	assert.Equal(t, 0, exitcode,
-		"EXITCODE is not the expected one")
+	assert.Equal(t, "Please use the 'chef' executable to access Upgrade Lab features.\n", out.String())
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }
 func TestHelpCommandDisplayHelpForCapture(t *testing.T) {
 	out, err, exitcode := ChefAnalyze("help", "capture")
@@ -99,41 +75,36 @@ Flags:
 
 func TestHelpCommandDisplayHelpForReport(t *testing.T) {
 	out, err, exitcode := ChefAnalyze("help", "report")
-	assert.Contains(t, out.String(),
-		"--chef-server-url",
-		"STDOUT chef-server-url flag doesn't exist")
-	assert.Contains(t, out.String(),
-		"--client-key",
-		"STDOUT client-key flag doesn't exist")
-	assert.Contains(t, out.String(),
-		"--client-name",
-		"STDOUT client-name flag doesn't exist")
-	assert.Contains(t, out.String(),
-		"--credentials",
-		"STDOUT credentials flag doesn't exist")
-	assert.Contains(t, out.String(),
-		"--help",
-		"STDOUT help flag doesn't exist")
-	assert.Contains(t, out.String(),
-		"--profile",
-		"STDOUT profile flag doesn't exist")
-	assert.Contains(t, out.String(),
-		"--format string",
-		"STDOUT format string flag doesn't exist")
-	assert.Contains(t,
-		out.String(),
-		"chef report [command]",
-		"STDOUT missing help about the report sub-command")
-	assert.Empty(t,
-		err.String(),
-		"STDERR should be empty")
-	assert.Equal(t, 0, exitcode,
-		"EXITCODE is not the expected one")
+	expected := `Generate reports from a Chef Infra Server
+
+Usage:
+  chef report [command]
+
+Available Commands:
+  cookbooks   Generates a cookbook-oriented report
+  nodes       Generates a nodes-oriented report
+
+Flags:
+  -s, --chef-server-url string   Chef Infra Server URL
+  -k, --client-key string        Chef Infra Server API client key
+  -n, --client-name string       Chef Infra Server API client name
+  -c, --credentials string       credentials file (default $HOME/.chef/credentials)
+  -f, --format string            output format: txt is human readable, csv is machine readable (default "txt")
+  -h, --help                     help for report
+  -F, --node-filter string       Search filter to apply to nodes
+  -p, --profile string           profile to use from credentials file (default "default")
+  -o, --ssl-no-verify            Do not verify SSL when connecting to Chef Infra Server (default: verify)
+
+Use "chef report [command] --help" for more information about a command.
+`
+	assert.Equal(t, expected, out.String())
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }
 
 func TestHelpCommandDisplayHelpForReportCookbooks(t *testing.T) {
 	out, err, exitcode := ChefAnalyze("help", "report", "cookbooks")
-	var expected = `Generates a cookbook-oriented report containing details about the
+	expected := `Generates a cookbook-oriented report containing details about the
 upgrade compatibility errors and node cookbook usage.
 
 The result is written to file.
@@ -157,12 +128,9 @@ Global Flags:
   -p, --profile string           profile to use from credentials file (default "default")
   -o, --ssl-no-verify            Do not verify SSL when connecting to Chef Infra Server (default: verify)
 `
-	assert.Equal(t, out.String(), expected)
-	assert.Empty(t,
-		err.String(),
-		"STDERR should be empty")
-	assert.Equal(t, 0, exitcode,
-		"EXITCODE is not the expected one")
+	assert.Equal(t, expected, out.String())
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }
 
 func TestHelpCommandDisplayHelpForReportNodes(t *testing.T) {
@@ -187,12 +155,9 @@ Global Flags:
   -o, --ssl-no-verify            Do not verify SSL when connecting to Chef Infra Server (default: verify)
 `
 
-	assert.Equal(t, out.String(), expected)
-	assert.Empty(t,
-		err.String(),
-		"STDERR should be empty")
-	assert.Equal(t, 0, exitcode,
-		"EXITCODE is not the expected one")
+	assert.Equal(t, expected, out.String())
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 
 }
 
@@ -200,13 +165,9 @@ func TestHelpCommandDisplayHelpFromUnknownCommand(t *testing.T) {
 	out, err, exitcode := ChefAnalyze("help", "foo")
 	// NOTE since this is an unknown command, we should display the help
 	// message via STDERR and not STDOUT
-	assert.Contains(t,
-		err.String(),
+	assert.Contains(t, err.String(),
 		"Use \"chef [command] --help\" for more information about a command.",
 		"STDERR bottom message doesn't match")
-	assert.Empty(t,
-		out.String(),
-		"STDOUT should be empty")
-	assert.Equal(t, 0, exitcode,
-		"EXITCODE is not the expected one")
+	assert.Empty(t, out.String(), "STDOUT should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }

--- a/integration/help_test.go
+++ b/integration/help_test.go
@@ -27,7 +27,7 @@ func TestHelpCommand(t *testing.T) {
 	out, err, exitcode := ChefAnalyze("help")
 	assert.Contains(t,
 		out.String(),
-		"Use \"chef-analyze [command] --help\" for more information about a command.",
+		"Use \"chef [command] --help\" for more information about a command.",
 		"STDOUT bottom message doesn't match")
 	assert.Empty(t,
 		err.String(),
@@ -40,7 +40,7 @@ func TestHelpFlags_h(t *testing.T) {
 	out, err, exitcode := ChefAnalyze("-h")
 	assert.Contains(t,
 		out.String(),
-		"Use \"chef-analyze [command] --help\" for more information about a command.",
+		"Use \"chef [command] --help\" for more information about a command.",
 		"STDOUT bottom message doesn't match")
 	assert.Empty(t,
 		err.String(),
@@ -53,7 +53,7 @@ func TestHelpFlags__help(t *testing.T) {
 	out, err, exitcode := ChefAnalyze("--help")
 	assert.Contains(t,
 		out.String(),
-		"Use \"chef-analyze [command] --help\" for more information about a command.",
+		"Use \"chef [command] --help\" for more information about a command.",
 		"STDOUT bottom message doesn't match")
 	assert.Empty(t,
 		err.String(),
@@ -66,7 +66,7 @@ func TestHelpNoArgs(t *testing.T) {
 	out, err, exitcode := ChefAnalyze()
 	assert.Contains(t,
 		out.String(),
-		"Use \"chef-analyze [command] --help\" for more information about a command.",
+		"Use \"chef [command] --help\" for more information about a command.",
 		"STDOUT bottom message doesn't match")
 	assert.Empty(t,
 		err.String(),
@@ -81,7 +81,7 @@ func TestHelpCommandDisplayHelpForCapture(t *testing.T) {
 can then be used to converge locally.
 
 Usage:
-  chef-analyze capture NODE-NAME [flags]
+  chef capture NODE-NAME [flags]
 
 Flags:
   -s, --chef-server-url string   Chef Infra Server URL
@@ -122,7 +122,7 @@ func TestHelpCommandDisplayHelpForReport(t *testing.T) {
 		"STDOUT format string flag doesn't exist")
 	assert.Contains(t,
 		out.String(),
-		"chef-analyze report [command]",
+		"chef report [command]",
 		"STDOUT missing help about the report sub-command")
 	assert.Empty(t,
 		err.String(),
@@ -133,16 +133,13 @@ func TestHelpCommandDisplayHelpForReport(t *testing.T) {
 
 func TestHelpCommandDisplayHelpForReportCookbooks(t *testing.T) {
 	out, err, exitcode := ChefAnalyze("help", "report", "cookbooks")
-	var expected = `Generates cookbook oriented reports containing details about the number of
-violations each cookbook has, which violations can be are auto-corrected and
-the number of nodes using each cookbook.
+	var expected = `Generates a cookbook-oriented report containing details about the
+upgrade compatibility errors and node cookbook usage.
 
-These reports could take a long time to run depending on the number of cookbooks
-to analyze and therefore reports will be written to disk. The location will be
-provided when the report is generated.
+The result is written to file.
 
 Usage:
-  chef-analyze report cookbooks [flags]
+  chef report cookbooks [flags]
 
 Flags:
   -h, --help             help for cookbooks
@@ -170,10 +167,11 @@ Global Flags:
 
 func TestHelpCommandDisplayHelpForReportNodes(t *testing.T) {
 	out, err, exitcode := ChefAnalyze("help", "report", "nodes")
-	var expected = `Generates a nodes oriented report
+	var expected = `Generates a nodes-oriented report containing basic information about the node,
+any applied policies, and the cookbooks used during the most recent chef-client run
 
 Usage:
-  chef-analyze report nodes [flags]
+  chef report nodes [flags]
 
 Flags:
   -h, --help   help for nodes
@@ -188,6 +186,7 @@ Global Flags:
   -p, --profile string           profile to use from credentials file (default "default")
   -o, --ssl-no-verify            Do not verify SSL when connecting to Chef Infra Server (default: verify)
 `
+
 	assert.Equal(t, out.String(), expected)
 	assert.Empty(t,
 		err.String(),
@@ -203,7 +202,7 @@ func TestHelpCommandDisplayHelpFromUnknownCommand(t *testing.T) {
 	// message via STDERR and not STDOUT
 	assert.Contains(t,
 		err.String(),
-		"Use \"chef-analyze [command] --help\" for more information about a command.",
+		"Use \"chef [command] --help\" for more information about a command.",
 		"STDERR bottom message doesn't match")
 	assert.Empty(t,
 		out.String(),

--- a/pkg/dist/global.go
+++ b/pkg/dist/global.go
@@ -13,6 +13,7 @@ const (
 	AutomateProduct    = "Chef Automate"
 	ClientExec         = "chef-client"
 	ClientProduct      = "Chef Infra Client"
+	CLIWrapperExec     = "chef"
 	CompanyName        = "Chef Software"
 	DirSuffix          = "chef"
 	DocsWebsite        = "https://docs.chef.io"


### PR DESCRIPTION
This updates descriptions and usage text to reflect
the new entry point of 'chef report', 'chef capture' instead of
'chef-analyze'.

This includes an alias for `upload` so that it can be accessed from
the `chef` invocation `chef report upload` -> `chef-analyze upload`,
and render the correct usage text.

Text corrections have also been made for clarity and consistency with other
CLI tool conventions.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
