### PR TITLE
capture: several small UI tweaks

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -143,6 +143,9 @@ can then be used to converge locally.`,
 				if err != nil {
 					return err
 				}
+				if len(cookbooks) == 0 {
+					break
+				}
 				path = requestCookbookPath(cookbooks)
 			}
 

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -165,8 +165,15 @@ func init() {
 	addInfraFlagsToCommand(captureCmd)
 }
 func requestCookbookPathFullMessage(repoPath string, cookbooks []reporting.NodeCookbook) string {
-	fmt.Printf(CookbookCaptureGatherSourcesTxt, repoPath, formatCookbooks(cookbooks))
-	var path string
+	var input, path string
+
+	// We issue a long instruction and ask to press Enter to continue.
+	// This is out of fear that a long cookbook list would scroll the
+	// instructions off the screen.
+	fmt.Printf(CookbookCaptureGatherSourcesTxt, repoPath)
+	fmt.Scanf("%s\n", &input) // discarded
+
+	fmt.Printf(CookbookCaptureRequestCookbookPathTxt, formatCookbooks(cookbooks))
 	fmt.Scanf("%s\n", &path)
 	return path
 }

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -186,7 +186,7 @@ func formatCookbooks(cookbooks []reporting.NodeCookbook) string {
 
 // For a given `sourcePath`, replace copy of cookbook in repoDir/cookbooks/CB
 // with a symlink to cookbooks found in the provided source.
-// TODO: In the unlikley event that user directories are using FAT
+// TODO: In the unlikely event that user directories are using FAT
 //       symlinking will not work.
 // TODO (future) - split terminal IO, and move this into an appropriate package.
 func resolveCookbooks(cookbooks []reporting.NodeCookbook, repoDir string, sourcePath string) ([]reporting.NodeCookbook, error) {
@@ -199,7 +199,7 @@ func resolveCookbooks(cookbooks []reporting.NodeCookbook, repoDir string, source
 		targetPath, _ := filepath.Abs(fmt.Sprintf("%s/cookbooks/%s", repoDir, cb.Name))
 		sourcePath, _ := filepath.Abs(fmt.Sprintf("%s/%s", sourcePath, cb.Name))
 		if _, err := os.Stat(sourcePath); err == nil {
-			fmt.Printf("  Replacing cookbook: %s\n", cb.Name)
+			fmt.Printf("  Using your checked-out cookbook: %s\n", cb.Name)
 			savedTargetPath := fmt.Sprintf("%s.server", targetPath)
 			err := os.Rename(targetPath, savedTargetPath)
 			if err != nil {

--- a/cmd/text.go
+++ b/cmd/text.go
@@ -23,14 +23,18 @@ package cmd
 const (
 	// Param 1: cookbook directory in repository.
 	// Param 2: newline-separated list of cookbooks
-	CookbooksNotSourcedTxt = `Changes made to the following cookbooks in %s
+	CookbooksNotSourcedTxt = `
+------------------------ WARNING ---------------------------
+Changes made to the following cookbooks in %s
 cannot be saved upstream, though they can still be uploaded
 to a Chef Server:
 
 %s
 
+-----------------------------------------------------------
 `
-	CookbookCaptureCompleteTxt = `You're ready to begin!
+	CookbookCaptureCompleteTxt = `
+You're ready to begin!
 
 Start with 'kitchen converge'.  As you identify issues, you
 can modify cookbooks in their original checkout locations or
@@ -38,29 +42,29 @@ in the repository's cookbooks directory and they will be picked
 up on subsequent runs of 'kitchen converge'.
 `
 	// Param 1: repository directory
-	// Param 2: newline-separated space-indented list of cookbooks
 	CookbookCaptureGatherSourcesTxt = `
 Repository has been created in '%s'.
 
-Please clone or check out the following cookbooks locally
-from their original sources, and provide the base path
-for the checkout:
-
-%s
+Next, locate version-controlled copies of the cookbooks. This is
+important so that you can track changes to the cookbooks as you
+edit them. You may have one or more existing paths where you have
+checked out cookbooks. If not, now is a good time to open a
+separate terminal and clone or check out the cookbooks.
 
 If all cookbooks are not available in the same base location,
 you will have a chance to provide additional locations.
 
-If sources are not available for these cookbooks, leave this blank.
-
-Checkout Location [none]: `
+Press Enter to Continue:`
 
 	// Param 1: newline-separated space-indented list of cookbooks
 	CookbookCaptureRequestCookbookPathTxt = `
-Please provide the base checkout path for the following
-cookbooks, or leave blank if no more cookbooks are checked out:
+Please clone or check out the following cookbooks locally
+from their original sources, and provide the base path
+for the checkout of the following cookbooks:
 
 %s
+
+If sources are not available for these cookbooks, leave this blank.
 
 Checkout Location [none]: `
 )


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Smoothes some wording in the capture cookbook location loop, mainly by being a lot more verbose - which could be good or bad, depending on perspective.  I've added a "Press Enter to Continue" prompt to keep instructions from scrolling off prior to displaying the cookbook list, which is of unpredictable length.

I stopped short of adding color, because doing so can't really be done in plain text (you really need a function, because you need to detect platform, then decide what to do) and that would involve changing how this whole area of code works. We could add asterisks or something, if more emphasis is wanted.

Sample run:
```
 - Setting up local repository
 - Capturing node object 'node-01'
 - Capturing cookbooks...
 - Capturing environment...
 - Capturing roles...
 - Writing kitchen configuration...

Repository has been created in './node-node-01-repo'.

Next, locate version-controlled copies of the cookbooks. This is
important so that you can track changes to the cookbooks as you
edit them. You may have one or more existing paths where you have
checked out cookbooks. If not, now is a good time to open a
separate terminal and clone or check out the cookbooks.

If all cookbooks are not available in the same base location,
you will have a chance to provide additional locations.

Press Enter to Continue:

Please clone or check out the following cookbooks locally
from their original sources, and provide the base path
for the checkout of the following cookbooks:

  - cron (v1.7.5)
  - upgrade_lab_problems (v0.1.0)

If sources are not available for these cookbooks, leave this blank.

Checkout Location [none]: /src/my-cookbooks
  Using your checked-out cookbook: cron
  Using your checked-out cookbook: upgrade_lab_problems

You're ready to begin!

Start with 'kitchen converge'.  As you identify issues, you
can modify cookbooks in their original checkout locations or
in the repository's cookbooks directory and they will be picked
up on subsequent runs of 'kitchen converge'.
```


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #252 
Fixes #260

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [*] I have read the **CONTRIBUTING** document.
- [*] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [*] All new and existing tests passed.
- [*] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
