### PR TITLE
Policyfile capture support

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/chef/chef-analyze/pkg/reporting"
+	chef "github.com/chef/go-chef"
 	"github.com/chef/go-libs/credentials"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -33,8 +34,15 @@ import (
 var (
 	// behavior:
 	//  - repo dir: if it does not exist, we will create it by invoking chef generate repo node-NAME-repo.
-	//  - capture json object definitions for node, env, roles. Save them to the chef-repo.
-	//  - capture cookbooks and versions from automatic attributes. Save each cookbook @ version to the chef-repo.
+	//  - capture json object definitions for node,  and (env, roles) or (policy_group, active-policy-revision) .
+	//    Save them to the chef-repo.
+	//  - for policy-managed nodes, capture cookbook-artifacts from server based on policy
+	//    and policy_group assigned to node. Save each artifact to the chef-repo.
+	//  - for non-policy, capture cookbooks and versions from automatic attributes. Save each
+	//    cookbook @ version to the chef-repo.
+	//  - Offer user chance to symlink in cookbooks/cookbook artifacts from one or more locations
+	//    on the Workstation system.
+
 	// Possible options (future)
 	// --repo-dir -> root dir of repo to use.  Will update existing if one exists.
 	// Thoughts: this may make it harder to coordinate, now user will have to track telling kitchen about
@@ -75,12 +83,12 @@ can then be used to converge locally.`,
 
 			repoName := fmt.Sprintf("node-%s-repo", nodeName)
 			// TODO - future iteration - give option to set the destination path.
-			dirName := fmt.Sprintf("./%s", repoName)
+			repoDirName := fmt.Sprintf("./%s", repoName)
 
 			// abort if it exists, have them remove it first.
-			_, err = os.Stat(dirName)
+			_, err = os.Stat(repoDirName)
 			if err == nil {
-				fmt.Printf(RepositoryAlreadyExistsE002, dirName, nodeName)
+				fmt.Printf(RepositoryAlreadyExistsE002, repoDirName, nodeName)
 				return nil
 			} else {
 				if !os.IsNotExist(err) {
@@ -96,12 +104,12 @@ can then be used to converge locally.`,
 			}
 
 			// Some files are created that we don't need in our repo, let's remove them
-			err = os.RemoveAll(fmt.Sprintf("%s/cookbooks/example", dirName))
+			err = os.RemoveAll(fmt.Sprintf("%s/cookbooks/example", repoDirName))
 			if err != nil {
 				return errors.Wrap(err, "Could not remove pre-created repo content: example cookbook")
 			}
 
-			err = os.RemoveAll(fmt.Sprintf("%s/data_bags/example", dirName))
+			err = os.RemoveAll(fmt.Sprintf("%s/data_bags/example", repoDirName))
 			if err != nil {
 				return errors.Wrap(err, "Could not remove pre-created repo content: example data bag")
 			}
@@ -109,9 +117,12 @@ can then be used to converge locally.`,
 			capturer := reporting.NewNodeCapturer(
 				chefClient.Nodes, chefClient.Roles,
 				chefClient.Environments, chefClient.Cookbooks,
-				&reporting.ObjectWriter{RootDir: dirName},
+				chefClient.PolicyGroups,
+				chefClient.Policies,
+				chefClient.CookbookArtifacts,
+				&reporting.ObjectWriter{RootDir: repoDirName},
 			)
-			nc := reporting.NewNodeCapture(nodeName, dirName, capturer)
+			nc := reporting.NewNodeCapture(nodeName, repoDirName, capturer)
 			go nc.Run()
 			for progress := range nc.Progress {
 				switch progress {
@@ -125,6 +136,11 @@ can then be used to converge locally.`,
 					fmt.Println(" - Capturing environment...")
 				case reporting.WritingKitchenConfig:
 					fmt.Println(" - Writing kitchen configuration...")
+				case reporting.FetchingCookbookArtifacts:
+					fmt.Println(" - Capturing cookbook artifacts...")
+				case reporting.FetchingPolicyData:
+					fmt.Println(" - Capturing policy data...")
+
 				case reporting.FetchingComplete:
 				}
 			}
@@ -132,62 +148,84 @@ can then be used to converge locally.`,
 				return nc.Error
 			}
 
-			cookbooks := nc.Cookbooks
-			path := requestCookbookPathFullMessage(dirName, cookbooks)
+			var remainingCBs []reporting.NodeCookbook
+			var cookbookDirName string
+			if nc.Policy == nil {
+				remainingCBs = nc.Cookbooks
+				cookbookDirName = "cookbooks"
+			} else {
+				remainingCBs = locksToCookbooks(nc.Policy.CookbookLocks)
+				cookbookDirName = "cookbook_artifacts"
+			}
 
 			// Try to gather sources for all cookbooks; stop when we've found
 			// them all or the operator provides a blank input when asked for a new
 			// path.
-			for ok := true; ok; ok = (path != "" && len(cookbooks) > 0) {
-				cookbooks, err = resolveCookbooks(cookbooks, dirName, path)
+			requestGatherSources(repoDirName)
+			baseUserPath := requestCookbookPath(remainingCBs)
+			for len(remainingCBs) > 0 && baseUserPath != "" {
+				remainingCBs, err = resolveCookbooks(cookbookDirName, remainingCBs, repoDirName, baseUserPath)
 				if err != nil {
 					return err
 				}
-				if len(cookbooks) == 0 {
-					break
-				}
-				path = requestCookbookPath(cookbooks)
+				baseUserPath = requestCookbookPath(remainingCBs)
 			}
 
-			if len(cookbooks) > 0 {
-				fmt.Printf(CookbooksNotSourcedTxt, fmt.Sprintf("%s/%s", dirName, "cookbooks"),
-					formatCookbooks(cookbooks),
-				)
+			if len(remainingCBs) > 0 {
+				fmt.Printf(CookbooksNotSourcedTxt, fmt.Sprintf("%s/%s", repoDirName, cookbookDirName),
+					formatCookbooks(remainingCBs))
 			}
 
-			fmt.Print(CookbookCaptureCompleteTxt, dirName)
+			fmt.Print(CookbookCaptureCompleteTxt, repoDirName)
 			return nil
+
 		},
 	}
 )
 
+func locksToCookbooks(locks map[string]chef.CookbookLock) []reporting.NodeCookbook {
+	var cbs = make([]reporting.NodeCookbook, 0)
+
+	for name, lock := range locks {
+		cbs = append(cbs, reporting.NodeCookbook{Name: name, Version: lock.Identifier})
+	}
+	return cbs
+}
+
 func init() {
 	addInfraFlagsToCommand(captureCmd)
 }
-func requestCookbookPathFullMessage(repoPath string, cookbooks []reporting.NodeCookbook) string {
-	var input, path string
-
-	// We issue a long instruction and ask to press Enter to continue.
-	// This is out of fear that a long cookbook list would scroll the
-	// instructions off the screen.
-	fmt.Printf(CookbookCaptureGatherSourcesTxt, repoPath)
-	fmt.Scanf("%s\n", &input) // discarded
-
-	fmt.Printf(CookbookCaptureRequestCookbookPathTxt, formatCookbooks(cookbooks))
-	fmt.Scanf("%s\n", &path)
-	return path
-}
 
 func requestCookbookPath(cookbooks []reporting.NodeCookbook) string {
-	fmt.Printf(CookbookCaptureRequestCookbookPathTxt, formatCookbooks(cookbooks))
-	var path string
-	fmt.Scanf("%s\n", &path)
-	return path
+
+	userPath := promptUser(fmt.Sprintf(CookbookCaptureRequestCookbookPathTxt, formatCookbooks(cookbooks)))
+	for len(userPath) > 0 {
+		absPath, _ := filepath.Abs(userPath)
+		if _, err := os.Stat(absPath); err == nil {
+			break
+		}
+		userPath = promptUser(fmt.Sprintf("'%s' is not a valid path. Cookbook Location [none]: ", userPath))
+	}
+	return userPath
+}
+
+func requestGatherSources(repoPath string) {
+	fmt.Printf(CookbookCaptureGatherSourcesTxt, repoPath)
+	promptUser(PressEnterToContinueTxt)
+}
+
+func promptUser(msg string) string {
+	fmt.Print(msg)
+	var answer string
+	fmt.Scanf("%s\n", &answer)
+	fmt.Println("") // Blank linke after taking input separates any response we may write
+	return answer
 }
 
 func formatCookbooks(cookbooks []reporting.NodeCookbook) string {
 	var cbNames []string
 	for _, cb := range cookbooks {
+		// TODO - do we want the hash shown for cookbook artifacts? Does it matter?
 		cbNames = append(cbNames, fmt.Sprintf("  - %s (v%s)", cb.Name, cb.Version))
 	}
 
@@ -199,30 +237,51 @@ func formatCookbooks(cookbooks []reporting.NodeCookbook) string {
 // TODO: In the unlikely event that user directories are using FAT
 //       symlinking will not work.
 // TODO (future) - split terminal IO, and move this into an appropriate package.
-func resolveCookbooks(cookbooks []reporting.NodeCookbook, repoDir string, sourcePath string) ([]reporting.NodeCookbook, error) {
-	if repoDir == "" {
+func resolveCookbooks(cookbookDirName string, cookbooks []reporting.NodeCookbook, repoDir string, sourcePath string) ([]reporting.NodeCookbook, error) {
+	if sourcePath == "" || repoDir == "" {
 		return cookbooks, nil
 	}
 
-	var unresolved []reporting.NodeCookbook
+	var (
+		targetPath string
+		unresolved []reporting.NodeCookbook
+	)
+	foundCount := 0
 	for _, cb := range cookbooks {
-		targetPath, _ := filepath.Abs(fmt.Sprintf("%s/cookbooks/%s", repoDir, cb.Name))
-		sourcePath, _ := filepath.Abs(fmt.Sprintf("%s/%s", sourcePath, cb.Name))
-		if _, err := os.Stat(sourcePath); err == nil {
-			fmt.Printf("  Using your checked-out cookbook: %s\n", cb.Name)
+		fullSourcePath, _ := filepath.Abs(fmt.Sprintf("%s/%s", sourcePath, cb.Name))
+		if cookbookDirName == "cookbooks" {
+			targetPath, _ = filepath.Abs(fmt.Sprintf("%s/cookbooks/%s", repoDir, cb.Name))
+		} else { // cookbook_artifacts
+			targetPath, _ = filepath.Abs(fmt.Sprintf("%s/cookbook_artifacts/%s-%s", repoDir, cb.Name, cb.Version))
+		}
+
+		if _, err := os.Stat(fullSourcePath); err == nil {
+
 			savedTargetPath := fmt.Sprintf("%s.server", targetPath)
 			err := os.Rename(targetPath, savedTargetPath)
 			if err != nil {
-				return nil, errors.Wrapf(err, "could not rename unsourced cookbook %s", targetPath)
+				return nil, errors.Wrapf(err, "could not rename unsourced cookbook %s to %s", targetPath, savedTargetPath)
 			}
-			os.Symlink(sourcePath, targetPath)
+			err = os.Symlink(fullSourcePath, targetPath)
 			if err != nil {
-				return nil, errors.Wrapf(err, "Could not link %s to %s", sourcePath, targetPath)
+				return nil, errors.Wrapf(err, "Could not link %s to %s", fullSourcePath, targetPath)
 			}
 
+			foundCount += 1
 		} else {
 			unresolved = append(unresolved, cb)
 		}
+
+	}
+
+	if len(unresolved) > 0 {
+		if foundCount > 0 {
+			fmt.Printf("  Found %d/%d cookbooks in %s\n", foundCount, len(cookbooks), sourcePath)
+		} else {
+			fmt.Printf("  No cookbooks found. Please check the path you provided: %s\n", sourcePath)
+		}
+	} else {
+		fmt.Printf("  Found all remaining cookbooks in %s\n", sourcePath)
 	}
 
 	return unresolved, nil

--- a/cmd/text.go
+++ b/cmd/text.go
@@ -55,8 +55,10 @@ separate terminal and clone or check out the cookbooks.
 
 If all cookbooks are not available in the same base location,
 you will have a chance to provide additional locations.
+`
 
-Press Enter to Continue:`
+	PressEnterToContinueTxt = `
+Press Enter to Continue: `
 
 	// Param 1: newline-separated space-indented list of cookbooks
 	CookbookCaptureRequestCookbookPathTxt = `

--- a/pkg/reporting/client_test.go
+++ b/pkg/reporting/client_test.go
@@ -59,9 +59,8 @@ func (cm CookbookMock) DownloadTo(name, version, localDir string) error {
 	return cm.desiredDownloadError
 }
 
-
 type CBAMock struct {
-	desiredCBAList chef.CBAGetResponse
+	desiredCBAList       chef.CBAGetResponse
 	desiredCBAListError  error
 	desiredDownloadError error
 	createDirOnDownload  bool
@@ -73,7 +72,7 @@ func (cm CBAMock) List() (chef.CBAGetResponse, error) {
 
 func (cm CBAMock) DownloadTo(name, id, localDir string) error {
 	if cm.createDirOnDownload {
-		dirToMock := filepath.Join(localDir, fmt.Sprintf("%s-%s", name, id))
+		dirToMock := filepath.Join(localDir, fmt.Sprintf("%v-%v", name, id[0:20]))
 		err := os.MkdirAll(dirToMock, os.ModePerm)
 		if err != nil {
 			panic(err)

--- a/pkg/reporting/cookbooks.go
+++ b/pkg/reporting/cookbooks.go
@@ -164,6 +164,12 @@ func NewCookbooksReport(
 	if err != nil {
 		return nil, err
 	}
+	// TODO - can we rethink order of operations here? I committed the original sin
+	// by saying "well, we need the number of cookbooks to process first", and
+	// gathering the cookbook list up front.
+	// But now we have two network operations here instead of one and it's rather
+	// an extension of a bad pattern...
+	//
 	cookbooksDir := filepath.Join(wsDir, analyzeCacheDir, analyzeCookbooksDir)
 	results, err := cbi.ListAvailableVersions("0")
 	if err != nil {

--- a/pkg/reporting/object_writer.go
+++ b/pkg/reporting/object_writer.go
@@ -33,6 +33,8 @@ type ObjectWriter struct {
 type ObjectWriterInterface interface {
 	WriteRole(*chef.Role) error
 	WriteEnvironment(*chef.Environment) error
+	WritePolicyRevision(*chef.RevisionDetailsResponse) error
+	WritePolicyGroup(string, *chef.PolicyGroup) error
 	WriteNode(*chef.Node) error
 	WriteContent(string, []byte) error
 }
@@ -50,6 +52,14 @@ func (ow *ObjectWriter) WriteEnvironment(env *chef.Environment) error {
 // Takes a chef.Role and saves it as json in RootDir/nodes
 func (ow *ObjectWriter) WriteNode(node *chef.Node) error {
 	return ow.WriteJSON("nodes", node.Name, node)
+}
+
+func (ow *ObjectWriter) WritePolicyRevision(policy *chef.RevisionDetailsResponse) error {
+	return ow.WriteJSON("policies", fmt.Sprintf("%s-%s", policy.Name, policy.RevisionID), policy)
+}
+
+func (ow *ObjectWriter) WritePolicyGroup(name string, pgroup *chef.PolicyGroup) error {
+	return ow.WriteJSON("policy_groups", name, pgroup)
 }
 
 // Writes "content" to RootDir/"fileName"


### PR DESCRIPTION
This adds chef-capture support for policy-managed nodes.

It works in the same way that it does for non-policy-managed nodes -
it will capture the node's state and dependencies (in this case - policy group/policy/cookbook
artifacts) from a Chef Infra Server, and saves it into a local 'captured node' repository 
where it's served up on test-kitchen VM via chef-zero. 

This differs from running policyfile tests in TK in that Kitchen itself won't attempt to
resolve or download any cookbook dependencies - it relies on chef capture having captured the complete node state, including policy/artifacts applied  into the node repo before kitchen converge.

This functionality relies on a new provisioner for TK, "chef_zero_capture". This
provisioner ships with chef-cli, and is now available in 3.0.4+ of the chef-cli gem. 
