### PR TITLE
Post just the % change and link in the PR coverage report comment

### DIFF
--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -50,11 +50,7 @@ function code_coverage_table() {
 \\n
 \\n :eyes: Read the <a href='$(buildkite_artifacts_url)'>uploaded HTML coverage report</a>
 \\n
-\\nFunction defined at | Function name | Coverage
-\\n------------------- | ------------- | ---------
-\\n
 EOF
-  awk '{ gsub(/github.com\/chef\/chef-analyze\//,""); printf "%s | %s | %s \\n", $1, $2, $3 }' < $COVERAGE_TXT
 }
 
 function coverage_decrease() {


### PR DESCRIPTION
Having a significant part of the full report showing up as comments
in PR was making it difficult to navigate feedback and comments

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
