### PR TITLE
Drop i386 from hab studio build

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -28,7 +28,7 @@ function build_cross_platform() {
   ( cd /src || return 1
     gox -output="bin/{{.Dir}}_{{.OS}}_{{.Arch}}" \
         -os="darwin linux windows" \
-        -arch="amd64 386"
+        -arch="amd64"
   )
 }
 


### PR DESCRIPTION
This is not a supported arch for any OS. And with golang 15.1 it's
giving us build errors on darwin/386, which is now unsupported.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
