### PR TITLE
GHCP -- Walk: ex1 repo orientation

### DIFF
--- a/.github/workflows/diagram-render-check.yml
+++ b/.github/workflows/diagram-render-check.yml
@@ -1,5 +1,8 @@
 name: Diagram render check
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/diagram-render-check.yml
+++ b/.github/workflows/diagram-render-check.yml
@@ -24,21 +24,12 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install Chromium for Mermaid CLI
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y chromium-browser || sudo apt-get install -y chromium
+      - name: Setup Chrome
+        id: chrome
+        uses: browser-actions/setup-chrome@v1
 
       - name: Configure browser path
-        run: |
-          if command -v chromium-browser >/dev/null 2>&1; then
-            echo "PUPPETEER_EXECUTABLE_PATH=$(command -v chromium-browser)" >> "$GITHUB_ENV"
-          elif command -v chromium >/dev/null 2>&1; then
-            echo "PUPPETEER_EXECUTABLE_PATH=$(command -v chromium)" >> "$GITHUB_ENV"
-          else
-            echo "Could not find chromium executable" >&2
-            exit 1
-          fi
+        run: echo "PUPPETEER_EXECUTABLE_PATH=${{ steps.chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
 
       - name: Validate Mermaid diagrams in markdown
         run: bash scripts/validate_mermaid.sh .

--- a/.github/workflows/diagram-render-check.yml
+++ b/.github/workflows/diagram-render-check.yml
@@ -1,0 +1,41 @@
+name: Diagram render check
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - 'release/**'
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  mermaid-render:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Install Chromium for Mermaid CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y chromium-browser || sudo apt-get install -y chromium
+
+      - name: Configure browser path
+        run: |
+          if command -v chromium-browser >/dev/null 2>&1; then
+            echo "PUPPETEER_EXECUTABLE_PATH=$(command -v chromium-browser)" >> "$GITHUB_ENV"
+          elif command -v chromium >/dev/null 2>&1; then
+            echo "PUPPETEER_EXECUTABLE_PATH=$(command -v chromium)" >> "$GITHUB_ENV"
+          else
+            echo "Could not find chromium executable" >&2
+            exit 1
+          fi
+
+      - name: Validate Mermaid diagrams in markdown
+        run: bash scripts/validate_mermaid.sh .

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -4,6 +4,92 @@ be a place for us, at Chef, to discuss about the design and usability, the
 flow of commands that we expect user to follow plus, we will start the
 documentation of this tool in an early stage.
 
+## Architecture
+
+The architecture map below uses real repository paths so each node maps to
+code that exists in this project.
+
+```mermaid
+flowchart TD
+  A[CLI Entry\nmain.go] --> B[Command Router\ncmd/root.go]
+  B --> C[Report Commands\ncmd/report.go]
+  B --> D[Capture Command\ncmd/capture.go]
+  C --> E[Reporting Service\npkg/reporting/*.go]
+  C --> F[Formatters\npkg/formatter/*.go]
+  C --> G[Report Output Writer\ncmd/report.go saveReport/saveErrorReport]
+  D --> E
+  E --> H[Chef API Adapter\npkg/reporting/client.go]
+  E --> I[Snapshot Writer\npkg/reporting/object_writer.go]
+  E --> J[Cookstyle Runner\npkg/reporting/cookstyle.go]
+  G --> K[Chef Workstation Filesystem\n$HOME/.chef-workstation/reports and errors]
+  I --> L[Captured Node Repo\n./node-<name>-repo]
+```
+
+### Data Flows
+
+1. Nodes report flow
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant CLI as cmd/report.go (nodes)
+  participant RS as pkg/reporting/nodes.go
+  participant CA as pkg/reporting/client.go
+  participant F as pkg/formatter/*.go
+  participant FS as Local Filesystem
+
+  U->>CLI: chef-analyze report nodes
+  CLI->>CA: NewChefClient(config + credentials)
+  CLI->>RS: GenerateNodesReport(client, filter, anonymize)
+  RS->>CA: Search.PartialExec("node", ...)
+  RS-->>CLI: []NodeReportItem
+  CLI->>F: MakeNodesReportTXT/CSV
+  CLI->>FS: saveReport + saveErrorReport
+```
+
+2. Cookbooks report flow
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant CLI as cmd/report.go (cookbooks)
+  participant CR as pkg/reporting/cookbooks.go
+  participant API as Chef Infra Server APIs
+  participant CS as pkg/reporting/cookstyle.go
+  participant F as pkg/formatter/*.go
+  participant FS as Local Filesystem
+
+  U->>CLI: chef-analyze report cookbooks
+  CLI->>CR: NewCookbooksReport(...)
+  CR->>API: ListAvailableVersions + policy/cookbook artifacts
+  CLI->>CR: Generate()
+  CR->>API: Download cookbook/cookbook artifact
+  CR->>API: Lookup nodes using cookbook version
+  CR->>CS: runCookstyleFor(record) (optional)
+  CR-->>CLI: Records + errors
+  CLI->>F: MakeCookbooksReportTXT/CSV
+  CLI->>FS: saveReport + saveErrorReport
+```
+
+3. Capture command flow
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant CLI as cmd/capture.go
+  participant NC as pkg/reporting/capture.go
+  participant API as Chef Infra Server APIs
+  participant OW as pkg/reporting/object_writer.go
+  participant R as Local Node Repo
+
+  U->>CLI: chef-analyze capture NODE
+  CLI->>NC: NewNodeCapture(...)
+  CLI->>NC: Run()
+  NC->>API: Fetch node, roles, env, cookbooks, policy, data bags
+  NC->>OW: Write JSON objects and config files
+  OW->>R: Write roles/, environments/, nodes/, data_bags/, policies/
+```
+
 ## Help Documentation
 
 ### Main help

--- a/scripts/validate_mermaid.sh
+++ b/scripts/validate_mermaid.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${1:-.}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+block_count=0
+
+# Find markdown files outside vendor and .git directories.
+md_list="$TMP_DIR/markdown_files.txt"
+find "$ROOT_DIR" \
+  -type d \( -name vendor -o -name .git \) -prune -o \
+  -type f -name "*.md" -print > "$md_list"
+
+while IFS= read -r md_file; do
+  in_mermaid=0
+  line_no=0
+  out_file=""
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_no=$((line_no + 1))
+
+    if [[ "$in_mermaid" -eq 0 ]]; then
+      if [[ "$line" == '```mermaid' ]]; then
+        block_count=$((block_count + 1))
+        out_file="$TMP_DIR/diagram_${block_count}.mmd"
+        : > "$out_file"
+        in_mermaid=1
+      fi
+      continue
+    fi
+
+    if [[ "$line" == '```' ]]; then
+      # Render each Mermaid block and fail fast on syntax/render errors.
+      # In CI, set PUPPETEER_EXECUTABLE_PATH to a browser binary when needed.
+      npx --yes @mermaid-js/mermaid-cli@11.4.1 \
+        -i "$out_file" \
+        -o "$TMP_DIR/diagram_${block_count}.svg" \
+        -q
+      in_mermaid=0
+      continue
+    fi
+
+    printf '%s\n' "$line" >> "$out_file"
+  done < "$md_file"
+
+  if [[ "$in_mermaid" -eq 1 ]]; then
+    echo "Unclosed mermaid block in $md_file (line $line_no)" >&2
+    exit 1
+  fi
+done < "$md_list"
+
+if [[ "$block_count" -eq 0 ]]; then
+  echo "No Mermaid diagrams found in markdown files."
+  exit 0
+fi
+
+echo "Validated $block_count Mermaid diagram(s)."

--- a/scripts/validate_mermaid.sh
+++ b/scripts/validate_mermaid.sh
@@ -5,6 +5,30 @@ ROOT_DIR="${1:-.}"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
+PUPPETEER_CFG="$TMP_DIR/puppeteer-config.json"
+if [[ -n "${PUPPETEER_EXECUTABLE_PATH:-}" ]]; then
+  cat > "$PUPPETEER_CFG" <<EOF
+{
+  "executablePath": "${PUPPETEER_EXECUTABLE_PATH}",
+  "args": [
+    "--no-sandbox",
+    "--disable-setuid-sandbox",
+    "--disable-dev-shm-usage"
+  ]
+}
+EOF
+else
+  cat > "$PUPPETEER_CFG" <<EOF
+{
+  "args": [
+    "--no-sandbox",
+    "--disable-setuid-sandbox",
+    "--disable-dev-shm-usage"
+  ]
+}
+EOF
+fi
+
 block_count=0
 
 # Find markdown files outside vendor and .git directories.
@@ -37,6 +61,7 @@ while IFS= read -r md_file; do
       npx --yes @mermaid-js/mermaid-cli@11.4.1 \
         -i "$out_file" \
         -o "$TMP_DIR/diagram_${block_count}.svg" \
+        -p "$PUPPETEER_CFG" \
         -q
       in_mermaid=0
       continue


### PR DESCRIPTION
Title: GHCP -- Walk: ex1 repo orientation

Summary
- Updated architecture docs to map nodes to real repository paths.
- Added 3 concrete Mermaid data flows (nodes report, cookbooks report, capture flow).
- Added CI diagram render validation workflow and script for Mermaid blocks in markdown.
- Plan: inline summary completed in this PR.
- Files/paths touched: docs/DESIGN.md, .github/workflows/diagram-render-check.yml, scripts/validate_mermaid.sh

Evidence
- Tests/logs/metrics: `bash scripts/validate_mermaid.sh .` (local run requires browser setup; CI workflow now installs Chromium and sets `PUPPETEER_EXECUTABLE_PATH` before running this validator).
- Coverage: not applicable (docs + CI workflow/script change only).

Risk & Rollback
- Risk: low
- Rollback: revert commit 06fe7a2

Review Focus
- Verify Mermaid diagrams in docs/DESIGN.md reflect actual repo paths and flows.
- Verify workflow installs Chromium and validator fails on broken Mermaid blocks.

Track
- Level: Walk
- Exercise: ex1
